### PR TITLE
fix parsing of comments

### DIFF
--- a/persister/whisper_schema.go
+++ b/persister/whisper_schema.go
@@ -93,6 +93,9 @@ func ReadWhisperSchemas(file string) (*WhisperSchemas, error) {
 		if item.name == "" {
 			continue
 		}
+		if strings.HasPrefix(item.name, "#") {
+			continue
+		}
 		patternStr := s.ValueOf("pattern")
 		if patternStr == "" {
 			return nil, fmt.Errorf("[persister] Empty pattern '%s' for [%s]", item.name)

--- a/persister/whisper_schema_test.go
+++ b/persister/whisper_schema_test.go
@@ -114,6 +114,19 @@ retentions = 1m:30d,1h:5y
 	)
 }
 
+func TestParseSchemasComment(t *testing.T) {
+	assertSchemas(t, `
+# This is a wild comment
+[carbon]
+pattern = ^carbon\.
+retentions = 60s:90d
+	`,
+		[]testcase{
+			testcase{"carbon", "^carbon\\.", "60s:90d"},
+		},
+	)
+}
+
 func TestParseSchemasSortingAndMatch(t *testing.T) {
 	// mixed record with and without priority. match metrics
 	assert := assert.New(t)


### PR DESCRIPTION
It looks like there is an error in the configparser to parse comments.
This results in item.name in the whisper_schema parser to end up with
the whole comment.

I will also try to fix the configparser, so that this isn't needed in the future, together with the other fix.
