### PR TITLE
Check for NaN values when parsing line protocol

### DIFF
--- a/points/points.go
+++ b/points/points.go
@@ -71,13 +71,13 @@ func ParseText(line string) (*Points, error) {
 
 	value, err := strconv.ParseFloat(row[1], 64)
 
-	if err != nil {
+	if err != nil || math.IsNaN(value) {
 		return nil, fmt.Errorf("bad message: %#v", line)
 	}
 
 	tsf, err := strconv.ParseFloat(row[2], 64)
 
-	if err != nil {
+	if err != nil || math.IsNaN(tsf) {
 		return nil, fmt.Errorf("bad message: %#v", line)
 	}
 

--- a/points/points_test.go
+++ b/points/points_test.go
@@ -51,6 +51,9 @@ func TestParseText(t *testing.T) {
 
 	// assertError("metric.name 42 4102545300\n")
 
+	assertError("metric.name NaN 1422642189\n")
+	assertError("metric.name 42 NaN\n")
+
 	assertOk("metric.name -42.76 1422642189\n",
 		OnePoint("metric.name", -42.76, 1422642189))
 


### PR DESCRIPTION
Go considers a 'NaN' string to be a valid Float ... but unfortunately
that's not actually something graphite-web or grafana knows how
to handle.

Much like the original carbon-cache, do not persist such values and
reject them.
https://github.com/graphite-project/carbon/blob/83b87729a98a7b8efb3f0119280da3f812614ea2/lib/carbon/protocols.py#L65

Fixes #17.
