### PR TITLE
Fixing makefile to work on FreeBSD

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
+all: go-carbon
+
 GO ?= go
 export GOPATH := $(CURDIR)/_vendor
-
-all: go-carbon
 
 go-carbon:
 	$(GO) build


### PR DESCRIPTION
Currently, the makefile on FreeBSD errors out when running (BSD) make, with the following error. 

```
make: don't know how to make =. Stop

make: stopped in /root/go-carbonold
```

The (very small) change allows the Makefile to be used on FreeBSD (without using gmake), while retaining all current functionality on linux boxes. 
