### PR TITLE
Add "sorted" write strategy

### DIFF
--- a/carbon/app.go
+++ b/carbon/app.go
@@ -70,6 +70,11 @@ func (app *App) configure() error {
 		}
 	}
 
+	if !(cfg.Cache.WriteStrategy == "max" ||
+		cfg.Cache.WriteStrategy == "sorted") {
+		return fmt.Errorf("go-carbon support only \"max\" or \"sorted\" write-strategy")
+	}
+
 	app.Config = cfg
 
 	return nil
@@ -256,6 +261,7 @@ func (app *App) Start() (err error) {
 	core.SetMetricInterval(conf.Common.MetricInterval.Value())
 	core.SetMaxSize(conf.Cache.MaxSize)
 	core.SetInputCapacity(conf.Cache.InputBuffer)
+	core.SetWriteStrategy(conf.Cache.WriteStrategy)
 	core.Start()
 
 	app.Cache = core

--- a/carbon/config.go
+++ b/carbon/config.go
@@ -57,8 +57,9 @@ type whisperConfig struct {
 }
 
 type cacheConfig struct {
-	MaxSize     int `toml:"max-size"`
-	InputBuffer int `toml:"input-buffer"`
+	MaxSize       int    `toml:"max-size"`
+	InputBuffer   int    `toml:"input-buffer"`
+	WriteStrategy string `toml:"write-strategy"`
 }
 
 type udpConfig struct {
@@ -125,8 +126,9 @@ func NewConfig() *Config {
 			Sparse:              false,
 		},
 		Cache: cacheConfig{
-			MaxSize:     1000000,
-			InputBuffer: 51200,
+			MaxSize:       1000000,
+			InputBuffer:   51200,
+			WriteStrategy: "max",
 		},
 		Udp: udpConfig{
 			Listen:        ":2003",

--- a/points/points.go
+++ b/points/points.go
@@ -20,8 +20,9 @@ type Point struct {
 
 // Points from carbon clients
 type Points struct {
-	Metric string
-	Data   []*Point
+	Metric      string
+	Data        []*Point
+	LastWriteTS int64
 }
 
 // New creates new instance of Points
@@ -39,6 +40,7 @@ func OnePoint(metric string, value float64, timestamp int64) *Points {
 				Timestamp: timestamp,
 			},
 		},
+		LastWriteTS: time.Now().UnixNano(),
 	}
 }
 


### PR DESCRIPTION
Алгоритм сортировки ("max" в терминологии Графита) который используется в go-carbon приводит к тому, что короткие серии никогда не будут записаны.
Этот патч добавляет поддержку "sorted" который гарантирует, что все серии когда-нибудь будут записаны.
