### PR TITLE
Add missing /etc/init.d/functions dependency

### DIFF
--- a/deploy/go-carbon.spec.centos
+++ b/deploy/go-carbon.spec.centos
@@ -11,6 +11,8 @@ URL:		https://github.com/lomik/go-carbon
 Source0:	%{name}.tar.gz
 BuildRoot:      %{_tmppath}/%{name}-%{version}
 
+Requires:  /etc/init.d/functions
+
 %description
 Golang implementation of Graphite/Carbon server with classic architecture: Agent -> Cache -> Persister
 


### PR DESCRIPTION
/etc/init.d/go-carbon uses /etc/init.d/functions and therefore
should depend on it. RH build system normally populates dependencies
automatically by scanning RPM content at build timee, but for some
reason it is not happening for published RPM, hence this PR.

Missing dependency on base system components can be left unnoticed
untils RPM is installd in a stripped down environment such as
official Centos:6 image
