### PR TITLE
A quick way to save cache

### DIFF
--- a/carbon-agent.go
+++ b/carbon-agent.go
@@ -160,7 +160,7 @@ func main() {
 		signal.Notify(c, syscall.SIGUSR2)
 		<-c
 		httpStop()
-		app.GraceStop()
+		app.Stop()
 	}()
 
 	go func() {

--- a/carbon/config.go
+++ b/carbon/config.go
@@ -60,6 +60,7 @@ type cacheConfig struct {
 	MaxSize       int    `toml:"max-size"`
 	InputBuffer   int    `toml:"input-buffer"`
 	WriteStrategy string `toml:"write-strategy"`
+	StateFile     string `toml:"state-file"`
 }
 
 type udpConfig struct {
@@ -129,6 +130,7 @@ func NewConfig() *Config {
 			MaxSize:       1000000,
 			InputBuffer:   51200,
 			WriteStrategy: "max",
+			StateFile:     "/tmp/go-carbon.dat",
 		},
 		Udp: udpConfig{
 			Listen:        ":2003",


### PR DESCRIPTION
Этот патч меняет способ сохранения метрик при закрытии go-carbon. 
Вместо того что-бы пытаться обновить тысячи файлов, быстрее зписать кэш в один большой файл, а при следующем старте загрузить. 

На моей тестовой виртуалке 500К метрик и 6М точек сбрасываются на диск за 2 минуты.
Если сохранять кэш в один файл это занимает 6 секунд. Если записывать в какой-нибудь tmpfs будет ещё быстрее. 
