### PR TITLE
Fix #77 - clean up go vet output

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,7 @@ submodules:
 
 test:
 	$(GO) test ./...
+	$(GO) vet ./...
 
 clean:
 	rm -f go-carbon

--- a/cache/cache_test.go
+++ b/cache/cache_test.go
@@ -42,7 +42,6 @@ func TestCache(t *testing.T) {
 
 func TestCacheCheckpoint(t *testing.T) {
 	t.SkipNow() // @TODO
-	return
 	cache := New()
 	cache.Start()
 	cache.SetOutputChanSize(0)

--- a/carbon/app_stop_test.go
+++ b/carbon/app_stop_test.go
@@ -6,7 +6,6 @@ import (
 	"runtime/pprof"
 	"testing"
 
-	"github.com/lomik/go-carbon/carbon"
 	"github.com/lomik/go-carbon/qa"
 	"github.com/stretchr/testify/assert"
 )
@@ -20,7 +19,7 @@ func TestStartStop(t *testing.T) {
 		qa.Root(t, func(root string) {
 			configFile := TestConfig(root)
 
-			app := carbon.New(configFile)
+			app := New(configFile)
 
 			assert.NoError(app.ParseConfig())
 			assert.NoError(app.Start())

--- a/logging/logger.go
+++ b/logging/logger.go
@@ -31,7 +31,7 @@ func init() {
 				err := std.Reopen()
 				logrus.Infof("HUP received, reopen log %#v", std.Filename())
 				if err != nil {
-					logrus.Errorf("Reopen log %#v failed: %#s", std.Filename(), err.Error())
+					logrus.Errorf("Reopen log %#v failed: %s", std.Filename(), err.Error())
 				}
 			}
 		}
@@ -102,7 +102,7 @@ func (l *FileLogger) fsWatch(filename string, quit chan bool) {
 
 				logrus.Infof("Reopen log %#v by fsnotify event", std.Filename())
 				if err != nil {
-					logrus.Errorf("Reopen log %#v failed: %#s", std.Filename(), err.Error())
+					logrus.Errorf("Reopen log %#v failed: %s", std.Filename(), err.Error())
 				}
 
 			case <-quit:

--- a/logging/rotate_test.go
+++ b/logging/rotate_test.go
@@ -13,7 +13,6 @@ import (
 
 func TestFsnotifyRotate(t *testing.T) {
 	t.SkipNow()
-	return
 
 	assert := assert.New(t)
 

--- a/persister/whisper_test.go
+++ b/persister/whisper_test.go
@@ -113,7 +113,7 @@ func TestShuffler(t *testing.T) {
 
 	total := 0
 	for b := range buckets {
-		assert.InEpsilon(t, float64(runlength)/4, buckets[b], (float64(runlength)/4)*.005, fmt.Sprintf("shuffle distribution is greater than .5% across 4 buckets after %d inputs", runlength))
+		assert.InEpsilon(t, float64(runlength)/4, buckets[b], (float64(runlength)/4)*.005, fmt.Sprintf("shuffle distribution is greater than .5%% across 4 buckets after %d inputs", runlength))
 		total += buckets[b]
 	}
 	assert.Equal(t, runlength, total, "total output of shuffle is not equal to input")

--- a/receiver/udp.go
+++ b/receiver/udp.go
@@ -258,6 +258,4 @@ func (rcv *UDP) Listen(addr *net.UDPAddr) error {
 
 		return nil
 	})
-
-	return nil
 }


### PR DESCRIPTION
- Fixes unreachable code in tests
- Corrects import cycle in carbon/app_stop_test.go
- Corrects invalid printf verbs in several tests
- Adds go vet to Makefile test target
