### PR TITLE
Corrects several init script bugs for debian

### DIFF
--- a/debian/go-carbon.init
+++ b/debian/go-carbon.init
@@ -5,23 +5,22 @@
 # Required-Stop:     $local_fs $network $remote_fs $syslog
 # Default-Start:     2 3 4 5
 # Default-Stop:      0 1 6
-# Short-Description: <Enter a short description of the software>
-# Description:       <Enter a long description of the software>
-#                    <...>
-#                    <...>
+# Short-Description: Carbon backend cache/persistence daemon
+# Description:       backend data caching and persistence daemon for
+#                    Graphite
 ### END INIT INFO
 
-# Author: Dave Rawks <drawks@2101-dhcp-167-3.savagebeast.com>
+# Author: Dave Rawks <dave@pandora.com>
 
 # Do NOT "set -e"
 
 # PATH should only include /usr/* if it runs after the mountnfs.sh script
 PATH=/sbin:/usr/sbin:/bin:/usr/bin
 DESC="go-carbon"
-NAME=go-carbon
+NAME="go-carbon"
 DAEMON=/usr/sbin/go-carbon
 PIDFILE=/var/run/$NAME.pid
-CONFIGFILE="/etc/$NAME/go-carbon.conf"
+CONFIGFILE="/etc/${NAME}/${NAME}.conf"
 DAEMON_ARGS="-config $CONFIGFILE -pidfile $PIDFILE -daemon"
 SCRIPTNAME=/etc/init.d/$NAME
 
@@ -53,18 +52,6 @@ do_start()
 	start-stop-daemon --start --quiet --pidfile $PIDFILE --exec $DAEMON -- \
 		$DAEMON_ARGS \
 		|| return 2
-	# The above code will not work for interpreted scripts, use the next
-	# six lines below instead (Ref: #643337, start-stop-daemon(8) )
-	#start-stop-daemon --start --quiet --pidfile $PIDFILE --startas $DAEMON \
-	#	--name $NAME --test > /dev/null \
-	#	|| return 1
-	#start-stop-daemon --start --quiet --pidfile $PIDFILE --startas $DAEMON \
-	#	--name $NAME -- $DAEMON_ARGS \
-	#	|| return 2
-
-	# Add code here, if necessary, that waits for the process to be ready
-	# to handle requests from services started subsequently which depend
-	# on this one.  As a last resort, sleep for some time.
 }
 
 #
@@ -77,19 +64,8 @@ do_stop()
 	#   1 if daemon was already stopped
 	#   2 if daemon could not be stopped
 	#   other if a failure occurred
-	start-stop-daemon --stop --quiet -s 12 -p --retry=TERM/30/KILL/15 --pidfile $PIDFILE --name $NAME
+	start-stop-daemon --stop --quiet --signal USR2 --pidfile $PIDFILE --exec $DAEMON
 	RETVAL="$?"
-	[ "$RETVAL" = 2 ] && return 2
-	# Wait for children to finish too if this is a daemon that forks
-	# and if the daemon is only ever run from this initscript.
-	# If the above conditions are not satisfied then add some other code
-	# that waits for the process to drop all resources that could be
-	# needed by services started subsequently.  A last resort is to
-	# sleep for some time.
-	start-stop-daemon --stop --quiet --oknodo -p --retry=0/30/KILL/5 --exec $DAEMON
-	[ "$?" = 2 ] && return 2
-	# Many daemons don't delete their pidfiles when they exit.
-	rm -f $PIDFILE
 	return "$RETVAL"
 }
 
@@ -102,7 +78,7 @@ do_reload() {
 	# restarting (for example, when it is sent a SIGHUP),
 	# then implement that here.
 	#
-	start-stop-daemon --stop --signal 1 --quiet --pidfile $PIDFILE --name $NAME
+	start-stop-daemon --stop --signal HUP --quiet --pidfile $PIDFILE --exec $DAEMON
 	return 0
 }
 


### PR DESCRIPTION
- Correct signal for graceful stopCorrects several init script bugs for
  debian.
- Remove forced stop on slow shutdown. If you are in a hurry you should
  do this yourself manually. Doing it automatically is a recipe for data
  loss.
- Remove pidfile deletion. This happens in process at the end of
  graceful shutdown.
- Correct description and attribution lines.
