### PR TITLE
Use whisper.TimeSeriesPoint straight from the start

### DIFF
--- a/cache/cache.go
+++ b/cache/cache.go
@@ -22,7 +22,7 @@ func (v byLength) Less(i, j int) bool { return len(v[i].Data) < len(v[j].Data) }
 
 func (v byTimestamp) Len() int           { return len(v) }
 func (v byTimestamp) Swap(i, j int)      { v[i], v[j] = v[j], v[i] }
-func (v byTimestamp) Less(i, j int) bool { return v[i].Data[0].Timestamp > v[j].Data[0].Timestamp }
+func (v byTimestamp) Less(i, j int) bool { return v[i].Data[0].Time > v[j].Data[0].Time }
 
 type WriteStrategy int
 
@@ -340,7 +340,7 @@ func (c *Cache) Dump(w io.Writer) error {
 
 	for _, p := range c.data { // every metric
 		for _, d := range p.Data { // every metric point
-			_, err := w.Write([]byte(fmt.Sprintf("%s %v %v\n", p.Metric, d.Value, d.Timestamp)))
+			_, err := w.Write([]byte(fmt.Sprintf("%s %v %v\n", p.Metric, d.Value, d.Time)))
 			if err != nil {
 				return err
 			}

--- a/cache/carbonlink.go
+++ b/cache/carbonlink.go
@@ -94,14 +94,14 @@ func (listener *CarbonlinkListener) packReply(query *Query) []byte {
 	if query != nil && query.InFlightData != nil {
 		for _, points := range query.InFlightData {
 			for _, item := range points.Data {
-				datapoints = append(datapoints, stalecucumber.NewTuple(item.Timestamp, item.Value))
+				datapoints = append(datapoints, stalecucumber.NewTuple(item.Time, item.Value))
 			}
 		}
 	}
 
 	if query != nil && query.CacheData != nil {
 		for _, item := range query.CacheData.Data {
-			datapoints = append(datapoints, stalecucumber.NewTuple(item.Timestamp, item.Value))
+			datapoints = append(datapoints, stalecucumber.NewTuple(item.Time, item.Value))
 		}
 	}
 

--- a/carbon/restore_test.go
+++ b/carbon/restore_test.go
@@ -31,45 +31,45 @@ func TestRestore(t *testing.T) {
 			&points.Points{
 				Metric: "m2",
 				Data: []points.Point{
-					points.Point{
-						Value:     2.000000,
-						Timestamp: 1470687039,
+					{
+						Value: 2.000000,
+						Time:  1470687039,
 					},
 				},
 			},
 			&points.Points{
 				Metric: "m1",
 				Data: []points.Point{
-					points.Point{
-						Value:     1.000000,
-						Timestamp: 1470687039,
+					{
+						Value: 1.000000,
+						Time:  1470687039,
 					},
 				},
 			},
 			&points.Points{
 				Metric: "m5",
 				Data: []points.Point{
-					points.Point{
-						Value:     5.000000,
-						Timestamp: 1470687217,
+					{
+						Value: 5.000000,
+						Time:  1470687217,
 					},
 				},
 			},
 			&points.Points{
 				Metric: "m4",
 				Data: []points.Point{
-					points.Point{
-						Value:     4.000000,
-						Timestamp: 1470687217,
+					{
+						Value: 4.000000,
+						Time:  1470687217,
 					},
 				},
 			},
 			&points.Points{
 				Metric: "m3",
 				Data: []points.Point{
-					points.Point{
-						Value:     3.000000,
-						Timestamp: 1470687217,
+					{
+						Value: 3.000000,
+						Time:  1470687217,
 					},
 				},
 			},

--- a/persister/whisper.go
+++ b/persister/whisper.go
@@ -117,9 +117,10 @@ func store(p *Whisper, values *points.Points) {
 		atomic.AddUint32(&p.created, 1)
 	}
 
+	// go-whisper API requires slice of pointers,not values for some reason
 	points := make([]*whisper.TimeSeriesPoint, len(values.Data))
-	for i, r := range values.Data {
-		points[i] = &whisper.TimeSeriesPoint{Time: int(r.Timestamp), Value: r.Value}
+	for i := range values.Data {
+		points[i] = (*whisper.TimeSeriesPoint)(&values.Data[i])
 	}
 
 	atomic.AddUint32(&p.committedPoints, uint32(len(values.Data)))

--- a/points/glue.go
+++ b/points/glue.go
@@ -43,7 +43,7 @@ func Glue(exit chan bool, in chan *Points, chunkSize int, chunkTimeout time.Dura
 		}
 
 		for _, d := range p.Data {
-			s := fmt.Sprintf("%s %v %v\n", p.Metric, d.Value, d.Timestamp)
+			s := fmt.Sprintf("%s %v %v\n", p.Metric, d.Value, d.Time)
 
 			if buf.Len()+len(s) > chunkSize {
 				flush()

--- a/points/points.go
+++ b/points/points.go
@@ -10,13 +10,10 @@ import (
 	"time"
 
 	"github.com/hydrogen18/stalecucumber"
+	"github.com/lomik/go-whisper"
 )
 
-// Point value/time pair
-type Point struct {
-	Value     float64
-	Timestamp int64
-}
+type Point whisper.TimeSeriesPoint
 
 // Points from carbon clients
 type Points struct {
@@ -34,9 +31,9 @@ func OnePoint(metric string, value float64, timestamp int64) *Points {
 	return &Points{
 		Metric: metric,
 		Data: []Point{
-			Point{
-				Value:     value,
-				Timestamp: timestamp,
+			{
+				Value: value,
+				Time:  int(timestamp),
 			},
 		},
 	}
@@ -169,8 +166,8 @@ func (p *Points) Append(onePoint Point) *Points {
 // Add value/timestamp pair to points
 func (p *Points) Add(value float64, timestamp int64) *Points {
 	p.Data = append(p.Data, Point{
-		Value:     value,
-		Timestamp: timestamp,
+		Value: value,
+		Time:  int(timestamp),
 	})
 	return p
 }
@@ -196,7 +193,7 @@ func (p *Points) Eq(other *Points) bool {
 		if p.Data[i].Value != other.Data[i].Value {
 			return false
 		}
-		if p.Data[i].Timestamp != other.Data[i].Timestamp {
+		if p.Data[i].Time != other.Data[i].Time {
 			return false
 		}
 	}

--- a/points/points_test.go
+++ b/points/points_test.go
@@ -91,8 +91,8 @@ func TestCopyAndEq(t *testing.T) {
 			Metric: "metric.name",
 		},
 		points.Copy().Append(Point{
-			Value:     42.15,
-			Timestamp: timestamp,
+			Value: 42.15,
+			Time:  int(timestamp),
 		}),
 	}
 


### PR DESCRIPTION
It avoids moving to heap every datapoint in persisters
and potentially allows to remove slice rebuild if go-whisper
is ever updated to receive slices of values, not pointers
