### PR TITLE
Fix extra dot after default graph prefix value

### DIFF
--- a/carbon/collector.go
+++ b/carbon/collector.go
@@ -72,7 +72,7 @@ func (c *Collector) collect() {
 
 	statModule := func(module string) func(metric string, value float64) {
 		return func(metric string, value float64) {
-			key := fmt.Sprintf("%s.%s.%s", c.graphPrefix, module, metric)
+			key := fmt.Sprintf("%s%s.%s", c.graphPrefix, module, metric)
 			logrus.Infof("[stat] %s=%#v", key, value)
 			select {
 			case c.data <- points.NowPoint(key, value):


### PR DESCRIPTION
Proper way would be to change default and examples, but
that would require config update for all the users
