### PR TITLE
Return error if carbonlink message is unrealistically large

### DIFF
--- a/cache/carbonlink.go
+++ b/cache/carbonlink.go
@@ -49,6 +49,10 @@ func ReadCarbonlinkRequest(reader io.Reader) ([]byte, error) {
 		return nil, fmt.Errorf("Can't read message length: %s", err.Error())
 	}
 
+	if msgLen > 1024 {
+		return nil, fmt.Errorf("Too big carbonlink request")
+	}
+
 	data := make([]byte, msgLen)
 
 	if err := binary.Read(reader, binary.BigEndian, data); err != nil {


### PR DESCRIPTION
instead of allocating possibly gigabytes of memory on
malformed message return and error.

Connection will be closed once ammended #98 is merged
