### PR TITLE
Handwritten pickle-unpickle operations

### DIFF
--- a/cache/carbonlink.go
+++ b/cache/carbonlink.go
@@ -90,7 +90,7 @@ func (listener *CarbonlinkListener) SetQueryTimeout(timeout time.Duration) {
 	listener.queryTimeout = timeout
 }
 
-func (listener *CarbonlinkListener) packReply(query *Query) []byte {
+func packReply(query *Query) []byte {
 	buf := new(bytes.Buffer)
 
 	var datapoints []interface{}
@@ -167,7 +167,7 @@ func (listener *CarbonlinkListener) HandleConnection(conn net.Conn) {
 					query = nil // empty reply
 				}
 
-				packed := listener.packReply(query)
+				packed := packReply(query)
 				if packed == nil {
 					break
 				}

--- a/cache/carbonlink.go
+++ b/cache/carbonlink.go
@@ -29,13 +29,109 @@ func NewCarbonlinkRequest() *CarbonlinkRequest {
 	return &CarbonlinkRequest{}
 }
 
+func pickleMaybeMemo(b *[]byte) bool { //"consumes" memo tokens
+	if len(*b) > 1 && (*b)[0] == 'q' {
+		*b = (*b)[2:]
+	}
+	return true
+}
+
+func pickleGetStr(buf *[]byte) (string, bool) {
+	if len(*buf) == 0 {
+		return "", false
+	}
+	b := *buf
+
+	if b[0] == 'U' { // short string
+		if len(b) >= 2 {
+			sLen := int(uint8(b[1]))
+			if len(b) >= 2+sLen {
+				*buf = b[2+sLen:]
+				return string(b[2 : 2+sLen]), true
+			}
+		}
+	} else if b[0] == 'T' { //long string
+		if len(b) >= 5 {
+			sLen := int(binary.LittleEndian.Uint32(b[1:]))
+			if len(b) >= 5+sLen {
+				*buf = b[5+sLen:]
+				return string(b[5 : 5+sLen]), true
+			}
+		}
+	}
+	return "", false
+}
+
+func expectBytes(b *[]byte, v []byte) bool {
+	if bytes.Index(*b, v) == 0 {
+		*b = (*b)[len(v):]
+		return true
+	} else {
+		return false
+	}
+}
+
+var badErr error = fmt.Errorf("Bad pickle message")
+
 // ParseCarbonlinkRequest from pickle encoded data
-func ParseCarbonlinkRequest(data []byte) (*CarbonlinkRequest, error) {
-	reader := bytes.NewReader(data)
+func ParseCarbonlinkRequest(d []byte) (*CarbonlinkRequest, error) {
+
+	if !(expectBytes(&d, []byte("\x80\x02}")) && pickleMaybeMemo(&d) && expectBytes(&d, []byte("("))) {
+		return nil, badErr
+	}
+
 	req := NewCarbonlinkRequest()
 
-	if err := stalecucumber.UnpackInto(req).From(stalecucumber.Unpickle(reader)); err != nil {
-		return nil, err
+	var Metric, Type string
+	var ok bool
+
+	if expectBytes(&d, []byte("U\x06metric")) {
+		if !pickleMaybeMemo(&d) {
+			return nil, badErr
+		}
+		if Metric, ok = pickleGetStr(&d); !ok {
+			return nil, badErr
+		}
+
+		if !(pickleMaybeMemo(&d) && expectBytes(&d, []byte("U\x04type")) && pickleMaybeMemo(&d)) {
+			return nil, badErr
+		}
+
+		if Type, ok = pickleGetStr(&d); !ok {
+			return nil, badErr
+		}
+
+		if !pickleMaybeMemo(&d) {
+			return nil, badErr
+		}
+
+		req.Metric = Metric
+		req.Type = Type
+	} else if expectBytes(&d, []byte("U\x04type")) {
+		if !pickleMaybeMemo(&d) {
+			return nil, badErr
+		}
+
+		if Type, ok = pickleGetStr(&d); !ok {
+			return nil, badErr
+		}
+
+		if !(pickleMaybeMemo(&d) && expectBytes(&d, []byte("U\x06metric")) && pickleMaybeMemo(&d)) {
+			return nil, badErr
+		}
+
+		if Metric, ok = pickleGetStr(&d); !ok {
+			return nil, badErr
+		}
+
+		if !pickleMaybeMemo(&d) {
+			return nil, badErr
+		}
+
+		req.Metric = Metric
+		req.Type = Type
+	} else {
+		return nil, badErr
 	}
 
 	return req, nil

--- a/cache/carbonlink_test.go
+++ b/cache/carbonlink_test.go
@@ -301,3 +301,23 @@ func TestParseCarbonlinkRequest(t *testing.T) {
 		}
 	}
 }
+
+func BenchmarkCarbonLinkPickleParse(b *testing.B) {
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			ParseCarbonlinkRequest([]byte(sampleCacheQuery))
+		}
+	})
+}
+
+func BenchmarkCarbonLinkPackReply(b *testing.B) {
+	p := points.OnePoint("carbon.agents.carbon_agent_server.param.size", 15, 1422795966).Add(15, 9000000).Add(16, 9000000)
+
+	q := Query{CacheData: p}
+
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			packReply(&q)
+		}
+	})
+}

--- a/cache/carbonlink_test.go
+++ b/cache/carbonlink_test.go
@@ -80,8 +80,8 @@ func TestCarbonlink(t *testing.T) {
 	err = binary.Read(conn, binary.BigEndian, data)
 	assert.NoError(err)
 
-	// {u'datapoints': [(1422797285, 42.17)]}
-	assert.Equal("\x80\x02}(X\n\x00\x00\x00datapoints](J\xe5)\xceTG@E\x15\xc2\x8f\\(\xf6\x86eu.", string(data))
+	// {'datapoints': [(1422797285, 42.17)]}
+	assert.Equal([]byte("\x80\x02}U\ndatapoints]J\xe5)\xceTG@E\x15\xc2\x8f\\(\xf6\x86as."), data)
 	cleanup()
 
 	/* MESSAGE 2 */
@@ -97,8 +97,8 @@ func TestCarbonlink(t *testing.T) {
 	err = binary.Read(conn, binary.BigEndian, data)
 	assert.NoError(err)
 
-	// {u'datapoints': [(1422797267, -42.14), (1422795966, 15.0)]}
-	assert.Equal("\x80\x02}(X\n\x00\x00\x00datapoints](J\xd3)\xceTG\xc0E\x11\xeb\x85\x1e\xb8R\x86J\xbe$\xceTG@.\x00\x00\x00\x00\x00\x00\x86eu.",
+	// {'datapoints': [(1422797267, -42.14), (1422795966, 15.0)]}
+	assert.Equal("\x80\x02}U\ndatapoints](J\xd3)\xceTG\xc0E\x11\xeb\x85\x1e\xb8R\x86J\xbe$\xceTG@.\x00\x00\x00\x00\x00\x00\x86es.",
 		string(data))
 	cleanup()
 
@@ -124,7 +124,7 @@ func TestCarbonlink(t *testing.T) {
 	err = binary.Read(conn, binary.BigEndian, data)
 	assert.NoError(err)
 
-	assert.Equal("\x80\x02}(X\n\x00\x00\x00datapoints](eu.", string(data))
+	assert.Equal("\x80\x02}U\ndatapoints]s.", string(data))
 	cleanup()
 
 	/* WRONG MESSAGE TEST */

--- a/cache/carbonlink_test.go
+++ b/cache/carbonlink_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 const sampleCacheQuery = "\x00\x00\x00Y\x80\x02}q\x01(U\x06metricq\x02U,carbon.agents.carbon_agent_server.cache.sizeq\x03U\x04typeq\x04U\x0bcache-queryq\x05u."
-const sampleCacheQuery2 = "\x00\x00\x00Y\x80\x02}q\x01(U\x06metricq\x02U,carbon.agents.carbon_agent_server.param.sizeq\x03U\x04typeq\x04U\x0bcache-queryq\x05u."
+const sampleCacheQuery2 = "\x00\x00\x00Y\x80\x02}q\x01(U\x04typeq\x04U\x0bcache-queryq\x05U\x06metricq\x02U,carbon.agents.carbon_agent_server.param.sizeq\x03u."
 
 func TestCarbonlink(t *testing.T) {
 	assert := assert.New(t)
@@ -278,8 +278,14 @@ func TestParseCarbonlinkRequest(t *testing.T) {
 				Type:   "cache-query",
 				Metric: "carbon.agents.carbon_agent_server.cache.size"},
 		},
+		{name: "Good query2",
+			data: []byte(sampleCacheQuery2)[4:],
+			want: &CarbonlinkRequest{
+				Type:   "cache-query",
+				Metric: "carbon.agents.carbon_agent_server.param.size"},
+		},
 		{name: "Invalid query type",
-			data: []byte("\x80\x02}q\x00(U\x06Metricq\x01U\x03barq\x02U\x04Typeq\x03U\x03fooq\x04u."),
+			data: []byte("\x80\x02}q\x00(U\x06metricq\x01U\x03barq\x02U\x04typeq\x03U\x03fooq\x04u."),
 			want: &CarbonlinkRequest{
 				Type:   "foo",
 				Metric: "bar",


### PR DESCRIPTION
Synthetic benchmark doesn't do it justice,  but tons of GC generated by `reflect` are limiting number CL requests in end-2-end benchmark by factor of two.

Synthetic differences you can see below

Before:

```
go test -bench "BenchmarkCarbonLink"  -run none .  -benchtime 10s -benchmem
PASS
BenchmarkCarbonLinkPickleParse-4    20000000           967 ns/op        1144 B/op          8 allocs/op
BenchmarkCarbonLinkPackReply-4       2000000          8957 ns/op        2688 B/op        120 allocs/op
```

After:

```
go test -bench "BenchmarkCarbonLink"  -run none .  -benchtime 10s -benchmem
PASS
BenchmarkCarbonLinkPickleParse-4    100000000          105 ns/op          96 B/op          1 allocs/op
BenchmarkCarbonLinkPackReply-4      30000000           458 ns/op         224 B/op          3 a
```
