### PR TITLE
Split all length prefix framing into own package

### DIFF
--- a/cache/carbonlink.go
+++ b/cache/carbonlink.go
@@ -325,9 +325,9 @@ func (listener *CarbonlinkListener) Listen(addr *net.TCPAddr) error {
 					logrus.Warningf("[carbonlink] Failed to accept connection: %s", err)
 					continue
 				}
-				framed_conn, _ := framing.NewConn(conn, byte(4), binary.BigEndian)
-				framed_conn.MaxFrameSize = 1048576 // 1MB max frame size for read and write
-				go listener.HandleConnection(*framed_conn)
+				framedConn, _ := framing.NewConn(conn, byte(4), binary.BigEndian)
+				framedConn.MaxFrameSize = 1048576 // 1MB max frame size for read and write
+				go listener.HandleConnection(*framedConn)
 			}
 		})
 

--- a/cache/carbonlink_test.go
+++ b/cache/carbonlink_test.go
@@ -1,7 +1,6 @@
 package cache
 
 import (
-	"bytes"
 	"encoding/binary"
 	"net"
 	"reflect"
@@ -65,7 +64,7 @@ func TestCarbonlink(t *testing.T) {
 		return conn, func() { conn.Close() }
 	}
 
-	var replyLength int32
+	var replyLength uint32
 	var data []byte
 
 	/* MESSAGE 1 */
@@ -240,45 +239,6 @@ func TestCarbonlinkErrors(t *testing.T) {
 		}
 		conn.Close()
 
-	}
-}
-
-func TestReadCarbonlinkRequest(t *testing.T) {
-
-	tests := []struct {
-		name    string
-		data    []byte
-		want    []byte
-		wantErr bool
-	}{
-		{name: "Empty reader",
-			data:    []byte{},
-			wantErr: true},
-		// Length is expected to be 32 bits
-		{name: "Short Length",
-			data:    []byte("\x00"),
-			wantErr: true},
-		{name: "Length, but no body",
-			data:    []byte("\x00\x00\x00\x01"),
-			wantErr: true},
-		{name: "Valid Length and body",
-			data: []byte("\x00\x00\x00\x01x"),
-			want: []byte("x"),
-		},
-		{name: "Length zero, no body",
-			data: []byte("\x00\x00\x00\x00"),
-			want: []byte(""),
-		},
-	}
-	for _, tt := range tests {
-		got, err := ReadCarbonlinkRequest(bytes.NewReader(tt.data))
-		if (err != nil) != tt.wantErr {
-			t.Errorf("%q. ReadCarbonlinkRequest() error = %v, wantErr %v", tt.name, err, tt.wantErr)
-			continue
-		}
-		if !reflect.DeepEqual(got, tt.want) {
-			t.Errorf("%q. ReadCarbonlinkRequest() = %v, want %v", tt.name, got, tt.want)
-		}
 	}
 }
 

--- a/carbon/benchmark_test.go
+++ b/carbon/benchmark_test.go
@@ -241,8 +241,8 @@ func carbonLinkWorker(i int, metrics []string, l *cache.CarbonlinkListener, numC
 
 	wgInitDone.Done() // notify that we are ready to start loop
 	wgBenchStart.Wait()
-	framed_conn, _ := framing.NewConn(NewMockStringConn(clReqs[i], 9999999).(net.Conn), byte(4), binary.BigEndian)
-	l.HandleConnection(*framed_conn)
+	framedConn, _ := framing.NewConn(NewMockStringConn(clReqs[i], 9999999).(net.Conn), byte(4), binary.BigEndian)
+	l.HandleConnection(*framedConn)
 }
 
 func startCarbonLink(b *testing.B, c *cache.Cache, metrics []string, numCLClients int, wgInitDone, wgBenchStart *sync.WaitGroup) *cache.CarbonlinkListener {

--- a/carbon/benchmark_test.go
+++ b/carbon/benchmark_test.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/lomik/go-carbon/cache"
+	"github.com/lomik/go-carbon/helper/framing"
 	"github.com/lomik/go-carbon/persister"
 	"github.com/lomik/go-carbon/points"
 	"github.com/lomik/go-carbon/receiver"
@@ -50,7 +51,7 @@ type MockAddr struct {
 
 func (a *MockAddr) String() string { return "mock" }
 
-func NewMockStringConn(s string, repeats int) net.Conn {
+func NewMockStringConn(s string, repeats int) io.ReadWriteCloser {
 	return &StringConn{
 		r:       strings.NewReader(s),
 		i:       0,
@@ -100,7 +101,7 @@ func receiverWorker(i int, metrics []string, r *receiver.TCP, numConnections int
 
 	wgInitDone.Done() // notify that we are ready to start loop
 	wgBenchStart.Wait()
-	r.HandleConnection(NewMockStringConn(s, iterCount))
+	r.HandleConnection(NewMockStringConn(s, iterCount).(net.Conn))
 }
 
 func startReceivers(b *testing.B, r *receiver.TCP, metrics []string, numConnections int, wgInitDone, wgBenchStart *sync.WaitGroup) {
@@ -240,7 +241,8 @@ func carbonLinkWorker(i int, metrics []string, l *cache.CarbonlinkListener, numC
 
 	wgInitDone.Done() // notify that we are ready to start loop
 	wgBenchStart.Wait()
-	l.HandleConnection(NewMockStringConn(clReqs[i], 9999999))
+	framed_conn, _ := framing.NewConn(NewMockStringConn(clReqs[i], 9999999).(net.Conn), byte(4), binary.BigEndian)
+	l.HandleConnection(*framed_conn)
 }
 
 func startCarbonLink(b *testing.B, c *cache.Cache, metrics []string, numCLClients int, wgInitDone, wgBenchStart *sync.WaitGroup) *cache.CarbonlinkListener {

--- a/helper/framing/conn.go
+++ b/helper/framing/conn.go
@@ -1,0 +1,168 @@
+// Package framing provides a prefix length framed net.Conn connection.
+//
+// It implements a wrapper around net.Conn that frames each packet with a size
+// prefix of length 1, 2 or 4 bytes of either little or big endianess.
+//
+// Original author: Adam Lindberg
+package framing
+
+import (
+	"encoding/binary"
+	"errors"
+	"io"
+	"math"
+	"net"
+)
+
+// Errors returned by framed connections.
+var (
+	// ErrPrefixLength is returned when an invalid prefix length is given.
+	ErrPrefixLength = errors.New("Invalid frame prefix length")
+	// ErrFrameTooLarge is returned from Write(b []byte) when b is larger than
+	// MaxFrameSize.
+	ErrFrameTooLarge = errors.New("Frame too large for buffer size")
+)
+
+// Conn wraps a net.Conn making it aware about frames and their size.
+type Conn struct {
+	// The inner net.Conn
+	net.Conn
+	// The frame size: 1, 2 or 4.
+	PrefixLength byte
+	// The endianess of the length prefix.
+	Endianess binary.ByteOrder
+	// The maximum size of a frame for the current prefix size.
+	MaxFrameSize uint
+	// The remaining bytes of the current frame
+	bytesLeft int
+}
+
+// NewConn returns a framing.Conn that acts like a net.Conn. prefixLength
+// should be one of 1, 2 or 4. endianess should be one of binary.BigEndian or
+// binary.LittleEndian.
+//
+// The difference to a normal net.Conn is that Read(b []byte) prefixes each
+// packet with a size and Write(b []byte) reads that size and waits for that
+// many bytes.
+//
+// A complementary ReadFrame()
+// function can be used to read and wait for a full frame.
+func NewConn(inner net.Conn, prefixLength byte, endianess binary.ByteOrder) (conn *Conn, err error) {
+	if !(prefixLength == 1 || prefixLength == 2 || prefixLength == 4) {
+		return nil, ErrPrefixLength
+	}
+
+	var max uint
+	switch prefixLength {
+	case 1:
+		max = math.MaxUint8
+	case 2:
+		max = math.MaxUint16
+	case 4:
+		max = math.MaxUint32
+	}
+
+	return &Conn{
+		Conn:         inner,
+		PrefixLength: prefixLength,
+		Endianess:    endianess,
+		MaxFrameSize: max,
+	}, nil
+}
+
+// Read implements net.Conn.Read(b []byte)
+func (f *Conn) Read(b []byte) (n int, err error) {
+	total := 0
+
+	if f.bytesLeft <= 0 {
+		frame_size, err := f.readSize()
+		if err != nil {
+			return total, err
+		}
+		f.bytesLeft = frame_size
+	}
+
+	for len(b) > 0 && f.bytesLeft > 0 {
+		size := min(f.bytesLeft, len(b))
+
+		n, err := f.Conn.Read(b[:size])
+		if err != nil {
+			return total, err
+		}
+		total += n
+		b = b[size:]
+		f.bytesLeft -= size
+	}
+
+	return total, nil
+}
+
+// ReadFrame returns the next full frame in the stream.
+func (f *Conn) ReadFrame() (frame []byte, err error) {
+	size, err := f.readSize()
+	if err != nil {
+		return nil, err
+	}
+
+	buf := make([]byte, size)
+	_, err = io.ReadFull(f.Conn, buf)
+	if err != nil {
+		return nil, err
+	}
+
+	return buf, nil
+}
+
+func (f *Conn) readSize() (size int, err error) {
+	switch f.PrefixLength {
+	case 1:
+		var s uint8
+		err = binary.Read(f.Conn, f.Endianess, &s)
+		size = int(s)
+	case 2:
+		var s uint16
+		err = binary.Read(f.Conn, f.Endianess, &s)
+		size = int(s)
+	case 4:
+		var s uint32
+		err = binary.Read(f.Conn, f.Endianess, &s)
+		size = int(s)
+	}
+	if err != nil {
+		return 0, err
+	}
+	if uint(size) > f.MaxFrameSize {
+		return 0, ErrPrefixLength
+	}
+	return size, nil
+}
+
+// Write implements net.Conn.Write(b []byte)
+func (f *Conn) Write(b []byte) (n int, err error) {
+	length := len(b)
+
+	if uint(length) > f.MaxFrameSize {
+		return 0, ErrFrameTooLarge
+	}
+	switch f.PrefixLength {
+	case 1:
+		err = binary.Write(f.Conn, f.Endianess, uint8(length))
+	case 2:
+		err = binary.Write(f.Conn, f.Endianess, uint16(length))
+	case 4:
+		err = binary.Write(f.Conn, f.Endianess, uint32(length))
+	}
+	if err != nil {
+		return 0, err
+	}
+
+	return f.Conn.Write(b)
+}
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	} else {
+		return b
+	}
+}

--- a/helper/framing/conn_test.go
+++ b/helper/framing/conn_test.go
@@ -1,0 +1,292 @@
+package framing_test
+
+import (
+	"bytes"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/lomik/go-carbon/helper/framing"
+)
+
+func Test1BigEndian(t *testing.T) {
+	run(t, 1, binary.BigEndian)
+}
+
+func Test2BigEndian(t *testing.T) {
+	run(t, 2, binary.BigEndian)
+}
+
+func Test4BigEndian(t *testing.T) {
+	run(t, 4, binary.BigEndian)
+}
+
+func Test1LittleEndian(t *testing.T) {
+	run(t, 1, binary.LittleEndian)
+}
+
+func Test2LittleEndian(t *testing.T) {
+	run(t, 2, binary.LittleEndian)
+}
+
+func Test4LittleEndian(t *testing.T) {
+	run(t, 4, binary.LittleEndian)
+}
+
+func run(t *testing.T, size byte, endianess binary.ByteOrder) {
+	message := "13 bytes long"
+
+	l, err := net.Listen("tcp", ":0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer l.Close()
+
+	port := l.Addr().(*net.TCPAddr).Port
+
+	go func() {
+		conn, err := net.Dial("tcp", ":"+strconv.Itoa(port))
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		framed, err := framing.NewConn(conn, size, endianess)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer framed.Close()
+
+		for i := 1; i <= 2; i++ {
+			if _, err := fmt.Fprintf(framed, message); err != nil {
+				t.Fatal(err)
+			}
+		}
+	}()
+
+	conn, err := l.Accept()
+	if err != nil {
+		t.Fatal(err)
+	}
+	framed, err := framing.NewConn(conn, size, endianess)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer framed.Close()
+
+	buf, err := framed.ReadFrame()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if msg := string(buf[:]); msg != message {
+		t.Fatalf("Unexpected message:\nGot:\t\t%s\nExpected:\t%s\n", msg, message)
+	}
+
+	fixed := make([]byte, 20) // More than 13
+	n, err := framed.Read(fixed)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n != 13 {
+		t.Fatal("Frame is not of correct size")
+	}
+	if msg := string(fixed[:13]); msg != message {
+		t.Fatalf("Unexpected message:\nGot:\t\t%s\nExpected:\t%s\n", msg, message)
+	}
+}
+
+func TestInvalidFrameSiz(t *testing.T) {
+	_, err := framing.NewConn(nil, 3, nil)
+	if err != framing.ErrPrefixLength {
+		t.Fail()
+	}
+}
+
+func TestPacketTooLarge(t *testing.T) {
+	max := uint(16)
+	size := byte(4)
+	conn, err := framing.NewConn(nil, size, nil)
+	conn.MaxFrameSize = max
+	if err != nil {
+		t.Fatal(err)
+	}
+	b := make([]byte, max+1)
+	_, err = conn.Write(b)
+	if err != framing.ErrFrameTooLarge {
+		t.Fail()
+	}
+}
+
+func TestMessageSmallerThanBuffer(t *testing.T) {
+	conn := &fake{ReadWriter: bytes.NewBuffer([]byte{4, 0, 1, 2, 3})}
+	framed, _ := framing.NewConn(&fake{ReadWriter: conn}, 1, nil)
+
+	first_b := make([]byte, 6)
+	first_n, first_err := framed.Read(first_b)
+	if first_n != 4 || first_err != nil {
+		t.Fatalf("first_n = %d, first_err = %#v", first_n, first_err)
+	}
+	if !bytes.Equal(first_b, []byte{0, 1, 2, 3, 0, 0}) {
+		t.Fatal(first_b)
+	}
+}
+
+func TestMessageBiggerThanBuffer(t *testing.T) {
+	conn := &fake{ReadWriter: bytes.NewBuffer([]byte{
+		6, 0, 1, 2, 3, 4, 5,
+		// [message 1      ]
+		//          ^ first read ends
+		4, 7, 8, 9, 10,
+		// [message 2 ]
+		// ^ second read ends
+		//          ^ third read ends
+	})}
+	framed, _ := framing.NewConn(&fake{ReadWriter: conn}, 1, nil)
+
+	first_b := make([]byte, 4)
+	first_n, first_err := framed.Read(first_b)
+	if first_n != 4 || first_err != nil {
+		t.Fatal(first_n, first_err)
+	}
+	if !bytes.Equal(first_b, []byte{0, 1, 2, 3}) {
+		t.Fatal(first_b)
+	}
+
+	second_b := make([]byte, 3)
+	second_n, second_err := framed.Read(second_b)
+	if second_n != 2 || second_err != nil {
+		t.Fatal(second_n, second_err)
+	}
+	if !bytes.Equal(second_b, []byte{4, 5, 0}) {
+		t.Fatal(second_b)
+	}
+
+	third_b := make([]byte, 5)
+	third_n, third_err := framed.Read(third_b)
+	if third_n != 4 || third_err != nil {
+		t.Fatal(third_n, third_err)
+	}
+	if !bytes.Equal(third_b, []byte{7, 8, 9, 10, 0}) {
+		t.Fatal(third_b)
+	}
+
+	fourth_b := make([]byte, 1)
+	fourth_n, fourth_err := framed.Read(fourth_b)
+	if fourth_n != 0 || fourth_err != io.EOF {
+		t.Fatal(fourth_n, fourth_err)
+	}
+
+}
+
+func TestInnerReadSizeError(t *testing.T) {
+	conn := &fake{
+		ReadWriter: bytes.NewBuffer([]byte{}),
+		err:        errors.New("InnerReadSizeError"),
+	}
+	framed, _ := framing.NewConn(conn, 1, nil)
+	b := make([]byte, 4)
+	_, err := framed.Read(b)
+	if err.Error() != "InnerReadSizeError" {
+		t.Fatal(err)
+	}
+}
+
+func TestInnerReadError(t *testing.T) {
+	conn := &fake{
+		ReadWriter: bytes.NewBuffer([]byte{4}),
+		err:        errors.New("InnerReadError"),
+	}
+	framed, _ := framing.NewConn(conn, 1, nil)
+	b := make([]byte, 4)
+	_, err := framed.Read(b)
+	if err.Error() != "InnerReadError" {
+		t.Fatal(err)
+	}
+}
+
+func TestInnerReadFrameSizeError(t *testing.T) {
+	conn := &fake{
+		ReadWriter: bytes.NewBuffer([]byte{}),
+		err:        errors.New("InnerReadFrameSizeError"),
+	}
+	framed, _ := framing.NewConn(conn, 1, nil)
+	_, err := framed.ReadFrame()
+	if err.Error() != "InnerReadFrameSizeError" {
+		t.Fatal(err)
+	}
+}
+
+func TestInnerReadFrameError(t *testing.T) {
+	conn := &fake{
+		ReadWriter: bytes.NewBuffer([]byte{4}),
+		err:        errors.New("InnerReadFrameError"),
+	}
+	framed, _ := framing.NewConn(conn, 1, nil)
+	_, err := framed.ReadFrame()
+	if err.Error() != "InnerReadFrameError" {
+		t.Fatal(err)
+	}
+}
+
+func TestWriteError(t *testing.T) {
+	conn := &fake{
+		ReadWriter: bytes.NewBuffer([]byte{}),
+		err:        errors.New("WriteError"),
+	}
+	framed, _ := framing.NewConn(conn, 1, nil)
+	_, err := framed.Write([]byte{0})
+	if err.Error() != "WriteError" {
+		t.Fatal(err)
+	}
+}
+
+type fake struct {
+	io.ReadWriter
+	err error
+}
+
+func (f *fake) Read(b []byte) (int, error) {
+	n, err := f.ReadWriter.Read(b)
+	if n == 0 {
+		if f.err != nil {
+			return 0, f.err
+		}
+		return 0, err
+	}
+	return n, err
+}
+
+func (f *fake) Write(b []byte) (int, error) {
+	if f.err != nil {
+		return 0, f.err
+	}
+	return f.ReadWriter.Write(b)
+}
+
+func (f *fake) Close() error {
+	return nil
+}
+
+func (f *fake) LocalAddr() net.Addr {
+	return nil
+}
+
+func (f *fake) RemoteAddr() net.Addr {
+	return nil
+}
+
+func (f *fake) SetDeadline(time time.Time) error {
+	return nil
+}
+
+func (f *fake) SetReadDeadline(time time.Time) error {
+	return nil
+}
+
+func (f *fake) SetWriteDeadline(time time.Time) error {
+	return nil
+}

--- a/helper/framing/conn_test.go
+++ b/helper/framing/conn_test.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"io"
 	"net"
-	"strconv"
 	"testing"
 	"time"
 
@@ -47,10 +46,8 @@ func run(t *testing.T, size byte, endianess binary.ByteOrder) {
 	}
 	defer l.Close()
 
-	port := l.Addr().(*net.TCPAddr).Port
-
 	go func() {
-		conn, err := net.Dial("tcp", ":"+strconv.Itoa(port))
+		conn, err := net.Dial("tcp", l.Addr().String())
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -62,7 +59,7 @@ func run(t *testing.T, size byte, endianess binary.ByteOrder) {
 		defer framed.Close()
 
 		for i := 1; i <= 2; i++ {
-			if _, err := fmt.Fprintf(framed, message); err != nil {
+			if _, err := fmt.Fprint(framed, message); err != nil {
 				t.Fatal(err)
 			}
 		}
@@ -125,13 +122,13 @@ func TestMessageSmallerThanBuffer(t *testing.T) {
 	conn := &fake{ReadWriter: bytes.NewBuffer([]byte{4, 0, 1, 2, 3})}
 	framed, _ := framing.NewConn(&fake{ReadWriter: conn}, 1, nil)
 
-	first_b := make([]byte, 6)
-	first_n, first_err := framed.Read(first_b)
-	if first_n != 4 || first_err != nil {
-		t.Fatalf("first_n = %d, first_err = %#v", first_n, first_err)
+	b1 := make([]byte, 6)
+	n1, err1 := framed.Read(b1)
+	if n1 != 4 || err1 != nil {
+		t.Fatalf("n1 = %d, err1 = %#v", n1, err1)
 	}
-	if !bytes.Equal(first_b, []byte{0, 1, 2, 3, 0, 0}) {
-		t.Fatal(first_b)
+	if !bytes.Equal(b1, []byte{0, 1, 2, 3, 0, 0}) {
+		t.Fatal(b1)
 	}
 }
 
@@ -147,37 +144,37 @@ func TestMessageBiggerThanBuffer(t *testing.T) {
 	})}
 	framed, _ := framing.NewConn(&fake{ReadWriter: conn}, 1, nil)
 
-	first_b := make([]byte, 4)
-	first_n, first_err := framed.Read(first_b)
-	if first_n != 4 || first_err != nil {
-		t.Fatal(first_n, first_err)
+	b1 := make([]byte, 4)
+	n1, err1 := framed.Read(b1)
+	if n1 != 4 || err1 != nil {
+		t.Fatal(n1, err1)
 	}
-	if !bytes.Equal(first_b, []byte{0, 1, 2, 3}) {
-		t.Fatal(first_b)
-	}
-
-	second_b := make([]byte, 3)
-	second_n, second_err := framed.Read(second_b)
-	if second_n != 2 || second_err != nil {
-		t.Fatal(second_n, second_err)
-	}
-	if !bytes.Equal(second_b, []byte{4, 5, 0}) {
-		t.Fatal(second_b)
+	if !bytes.Equal(b1, []byte{0, 1, 2, 3}) {
+		t.Fatal(b1)
 	}
 
-	third_b := make([]byte, 5)
-	third_n, third_err := framed.Read(third_b)
-	if third_n != 4 || third_err != nil {
-		t.Fatal(third_n, third_err)
+	b2 := make([]byte, 3)
+	n2, err2 := framed.Read(b2)
+	if n2 != 2 || err2 != nil {
+		t.Fatal(n2, err2)
 	}
-	if !bytes.Equal(third_b, []byte{7, 8, 9, 10, 0}) {
-		t.Fatal(third_b)
+	if !bytes.Equal(b2, []byte{4, 5, 0}) {
+		t.Fatal(b2)
 	}
 
-	fourth_b := make([]byte, 1)
-	fourth_n, fourth_err := framed.Read(fourth_b)
-	if fourth_n != 0 || fourth_err != io.EOF {
-		t.Fatal(fourth_n, fourth_err)
+	b3 := make([]byte, 5)
+	n3, err3 := framed.Read(b3)
+	if n3 != 4 || err3 != nil {
+		t.Fatal(n3, err3)
+	}
+	if !bytes.Equal(b3, []byte{7, 8, 9, 10, 0}) {
+		t.Fatal(b3)
+	}
+
+	b4 := make([]byte, 1)
+	n4, err4 := framed.Read(b4)
+	if n4 != 0 || err4 != io.EOF {
+		t.Fatal(n4, err4)
 	}
 
 }

--- a/receiver/pickle_test.go
+++ b/receiver/pickle_test.go
@@ -34,6 +34,18 @@ func TestPickle(t *testing.T) {
 	}
 }
 
+func TestBadPickle(t *testing.T) {
+	assert := assert.New(t)
+	test := newTCPTestCase(t, true)
+	defer test.Finish()
+
+	logging.Test(func(log logging.TestOut) {
+		test.Send("\x00\x00\x00#\x80\x02]q\x00q\x0bhello.worldq\x01Rixf8\xd3\x8eVK*\x86q\x02\x86q\x03a.")
+		time.Sleep(10 * time.Millisecond)
+		assert.Contains(log.String(), "I [pickle] Can't unpickle message")
+	})
+}
+
 // https://github.com/lomik/go-carbon/issues/30
 func TestPickleMemoryError(t *testing.T) {
 	assert := assert.New(t)
@@ -41,9 +53,9 @@ func TestPickleMemoryError(t *testing.T) {
 	defer test.Finish()
 
 	logging.Test(func(log logging.TestOut) {
-		test.Send("\x80\x00\x00\x00") // 2Gb message length
+		test.Send("\x80\x00\x00\x01") // 2Gb message length
 		time.Sleep(10 * time.Millisecond)
 
-		assert.Contains(log.String(), "W [pickle] Bad message size: 2147483648")
+		assert.Contains(log.String(), "W [pickle] Bad message")
 	})
 }

--- a/receiver/tcp.go
+++ b/receiver/tcp.go
@@ -107,7 +107,7 @@ func (rcv *TCP) HandleConnection(conn net.Conn) {
 }
 
 func (rcv *TCP) handlePickle(conn net.Conn) {
-	framed_conn, _ := framing.NewConn(conn, byte(4), binary.BigEndian)
+	framedConn, _ := framing.NewConn(conn, byte(4), binary.BigEndian)
 	defer func() {
 		if r := recover(); r != nil {
 			logrus.Errorf("[pickle] Unknown error recovered: %s", r)
@@ -132,11 +132,11 @@ func (rcv *TCP) handlePickle(conn net.Conn) {
 		}
 	})
 
-	framed_conn.MaxFrameSize = uint(rcv.maxPickleMessageSize)
+	framedConn.MaxFrameSize = uint(rcv.maxPickleMessageSize)
 
 	for {
 		conn.SetReadDeadline(time.Now().Add(2 * time.Minute))
-		data, err := framed_conn.ReadFrame()
+		data, err := framedConn.ReadFrame()
 		if err == framing.ErrPrefixLength {
 			atomic.AddUint32(&rcv.errors, 1)
 			logrus.Warningf("[pickle] Bad message size")

--- a/receiver/tcp.go
+++ b/receiver/tcp.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/lomik/go-carbon/helper"
+	"github.com/lomik/go-carbon/helper/framing"
 	"github.com/lomik/go-carbon/points"
 
 	"github.com/Sirupsen/logrus"
@@ -106,6 +107,7 @@ func (rcv *TCP) HandleConnection(conn net.Conn) {
 }
 
 func (rcv *TCP) handlePickle(conn net.Conn) {
+	framed_conn, _ := framing.NewConn(conn, byte(4), binary.BigEndian)
 	defer func() {
 		if r := recover(); r != nil {
 			logrus.Errorf("[pickle] Unknown error recovered: %s", r)
@@ -116,10 +118,6 @@ func (rcv *TCP) handlePickle(conn net.Conn) {
 	defer atomic.AddInt32(&rcv.active, -1)
 
 	defer conn.Close()
-	reader := bufio.NewReader(conn)
-
-	var msgLen uint32
-	var err error
 
 	finished := make(chan bool)
 	defer close(finished)
@@ -134,34 +132,16 @@ func (rcv *TCP) handlePickle(conn net.Conn) {
 		}
 	})
 
-	maxMessageSize := rcv.maxPickleMessageSize
+	framed_conn.MaxFrameSize = uint(rcv.maxPickleMessageSize)
 
 	for {
 		conn.SetReadDeadline(time.Now().Add(2 * time.Minute))
-
-		// Read prepended length
-		err = binary.Read(reader, binary.BigEndian, &msgLen)
-		if err != nil {
-			if err == io.EOF {
-				return
-			}
-
+		data, err := framed_conn.ReadFrame()
+		if err == framing.ErrPrefixLength {
 			atomic.AddUint32(&rcv.errors, 1)
-			logrus.Warningf("[pickle] Can't read message length: %s", err.Error())
+			logrus.Warningf("[pickle] Bad message size")
 			return
-		}
-
-		if msgLen > maxMessageSize {
-			atomic.AddUint32(&rcv.errors, 1)
-			logrus.Warningf("[pickle] Bad message size: %d", msgLen)
-			return
-		}
-
-		// Allocate a byte array of the expected length
-		data := make([]byte, msgLen)
-
-		// Read remainder of pickle packet into byte array
-		if err = binary.Read(reader, binary.BigEndian, data); err != nil {
+		} else if err != nil {
 			atomic.AddUint32(&rcv.errors, 1)
 			logrus.Warningf("[pickle] Can't read message body: %s", err.Error())
 			return


### PR DESCRIPTION
Doing length prefixed messaging framing always seemed like something best left up to an isolated utility package to me. So I factored it out into go-carbon/helper/framing.
