### PR TITLE
Correct error response to invalid query type on carbonlink

### DIFF
--- a/cache/carbonlink.go
+++ b/cache/carbonlink.go
@@ -285,6 +285,10 @@ func (listener *CarbonlinkListener) HandleConnection(conn net.Conn) {
 		if req != nil {
 			if req.Type != "cache-query" {
 				logrus.Warningf("[carbonlink] unknown query type: %#v", req.Type)
+				buf := bytes.NewBuffer([]byte(fmt.Sprintf("\x00\x00\x00\x00\x80\x02}q\x00U\x05errorq\x01U\x1aInvalid request type %qq\x02s.", req.Type)))
+				result := buf.Bytes()
+				binary.BigEndian.PutUint32(result[:4], uint32(buf.Len()-4))
+				conn.Write(result)
 				break
 			}
 

--- a/cache/carbonlink_test.go
+++ b/cache/carbonlink_test.go
@@ -144,7 +144,13 @@ func TestCarbonlink(t *testing.T) {
 
 	err = binary.Read(conn, binary.BigEndian, &replyLength)
 
-	assert.Error(err)
+	assert.NoError(err)
+	data = make([]byte, replyLength)
+
+	err = binary.Read(conn, binary.BigEndian, data)
+	assert.NoError(err)
+
+	assert.Equal("\x80\x02}q\x00U\x05errorq\x01U\x1aInvalid request type \"foo\"q\x02s.", string(data))
 	cleanup()
 }
 


### PR DESCRIPTION
Resolves #106, responds to invalid query types with same response as carbon reference implementation.
