### PR TITLE
Resolves #87

### DIFF
--- a/cache/carbonlink_test.go
+++ b/cache/carbonlink_test.go
@@ -46,8 +46,11 @@ func TestCarbonlink(t *testing.T) {
 	cache.In() <- msg3
 
 	defer cache.Stop()
-
-	time.Sleep(50 * time.Millisecond)
+	for {
+		if len(cache.In()) == 0 {
+			break
+		}
+	}
 
 	addr, err := net.ResolveTCPAddr("tcp", "localhost:0")
 	assert.NoError(err)


### PR DESCRIPTION
- wait for inputchan to be empty before moving forward on tests which
  retrieve from cache

I'm not 100% sure this is the correct strategy here, but in testing I have been unable to repeat the intermittent error from #87 with this change.
