### PR TITLE
carbonserver: fix panic when cache timestamp is equal to untilTime

### DIFF
--- a/carbonserver/carbonserver.go
+++ b/carbonserver/carbonserver.go
@@ -602,7 +602,7 @@ func (listener *CarbonserverListener) fetchSingleMetric(metric string, fromTime,
 		cacheStartTime := time.Now()
 		for _, item := range cacheData {
 			ts := int32(item.Timestamp) - int32(item.Timestamp)%step
-			if ts < fromTime || ts > untilTime {
+			if ts < fromTime || ts >= untilTime {
 				continue
 			}
 			index := (ts - fromTime) / step

--- a/carbonserver/carbonserver_test.go
+++ b/carbonserver/carbonserver_test.go
@@ -187,10 +187,10 @@ var singleMetricTests = []FetchTest{
 		now:              now,
 		errIsNil:         true,
 		dataIsNil:        false,
-		cachePoints:      []point{{now - 123, 7.0}, {now - 119, 7.1}, {now - 45, 7.3}, {now - 243, 6.9}, {now - 67, 7.2}},
+		cachePoints:      []point{{now - 123, 7.0}, {now - 119, 7.1}, {now - 45, 7.3}, {now - 243, 6.9}, {now - 67, 7.2}, {now + 3, 7.4}, {now + 67, 7.5}},
 		expectedStep:     60,
-		expectedValues:   []float64{0.1, 6.9, 0.3, 7.0, 7.2, 7.3, 0.0},
-		expectedIsAbsent: []bool{false, false, false, false, false, false, true},
+		expectedValues:   []float64{0.1, 6.9, 0.3, 7.0, 7.2, 7.3, 7.4},
+		expectedIsAbsent: []bool{false, false, false, false, false, false, false},
 	},
 	{
 		name:             "data-cache",


### PR DESCRIPTION
Because whisper fetches [fromTime, untilTime) (untilTime not included)
we need to ignore all cached points that's >= untilTime

This caused a panic from time to time.