### PR TITLE
Add a newline to -version output

### DIFF
--- a/go-carbon.go
+++ b/go-carbon.go
@@ -56,7 +56,7 @@ func main() {
 	flag.Parse()
 
 	if *printVersion {
-		fmt.Print(Version)
+		fmt.Println(Version)
 		return
 	}
 


### PR DESCRIPTION
go-carbon -version currently prints "0.9.0" without a newline, which isn't very nice. Change Print to Println.