### PR TITLE
Fix behavior of metric index if there is no metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,30 +137,41 @@ enabled = true
 read-timeout = "30s"
 
 [carbonserver]
+# Please NOTE: carbonserver is not intended to fully replace graphite-web
+# It acts as a "REMOTE_STORAGE" for graphite-web or carbonzipper/carbonapi
 listen = "127.0.0.1:8080"
 # Carbonserver support is still experimental and may contain bugs
 # Or be incompatible with github.com/grobian/carbonserver
 enabled = false
 # Buckets to track response times
 buckets = 10
-# Maximum amount of globs in a single metric
-max-globs = 100
 # carbonserver-specific metrics will be sent as counters
 # For compatibility with grobian/carbonserver
 metrics-as-counters = false
 # Read and Write timeouts for HTTP server
 read-timeout = "60s"
 write-timeout = "60s"
-# carbonserver keeps track of all available whisper files
-# in memory. This determines how often it will check FS
-# for new metrics.
-scan-frequency = "5m0s"
 # Enable /render cache, it will cache the result for 1 minute
 query-cache-enabled = true
 # 0 for unlimited
 query-cache-size-mb = 0
 # Enable /metrics/find cache, it will cache the result for 5 minutes
 find-cache-enabled = true
+# Control trigram index
+#  This index is used to speed-up /find requests
+#  However, it will lead to increased memory consumption
+#  Estimated memory consumption is approx. 500 bytes per each metric on disk
+#  Another drawback is that it will recreate index every scan-frequency interval
+#  All new/deleted metrics will still be searchable until index is recreated
+trigram-index = true
+# carbonserver keeps track of all available whisper files
+# in memory. This determines how often it will check FS
+# for new or deleted metrics.
+scan-frequency = "5m0s"
+# Maximum amount of globs in a single metric in index
+# This value is used to speed-up /find requests with
+# a lot of globs, but will lead to increased memory consumption
+max-globs = 100
 
 
 [dump]
@@ -234,8 +245,10 @@ With settings above applied, best write-strategy to use is "noop"
 * common: Logging refactored. Format changed to structured JSON. Added support of multiple logging handlers with separate output, level and encoding
 * dump/restore: New dump format
 * carbonserver: [feature] IdleTimeout is now configurable in carbonserver part
-* carbonserver: [feature] support /render query cache (query-cache-* options in config file)
-* carbonserver: [feature] support /metrics/find cache (find-cache-* option in config file)
+* carbonserver: [feature] support /render query cache (query-cache-\* options in config file)
+* carbonserver: [feature] support /metrics/find cache (find-cache-\* option in config file)
+* carbonserver: [feature] support /metrics/details handler, that returns information about metrics (require enabled trigram-index)
+* carbonserver: [feature] Add config option to disable trigram index (before that to disable index you should set scan-interval to 0)
 * carbonserver: [fix] fix #146 (metrics_known was broken if metrics were not sent as counters)
 
 ##### version 0.9.1

--- a/README.md
+++ b/README.md
@@ -172,6 +172,13 @@ scan-frequency = "5m0s"
 # This value is used to speed-up /find requests with
 # a lot of globs, but will lead to increased memory consumption
 max-globs = 100
+# graphtie-web-10-mode
+# Use Graphite-web 1.0 native structs for pickle response
+# This mode will break compatibility with graphite-web 0.9.x
+# If false, carbonserver won't send graphite-web 1.0 specific structs
+# That might degrade performance of the cluster
+# But will be compatible with both graphite-web 1.0 and 0.9.x
+graphtie-web-10-strict-mode = true
 
 
 [dump]

--- a/carbon/app.go
+++ b/carbon/app.go
@@ -315,6 +315,7 @@ func (app *App) Start() (err error) {
 		carbonserver.SetFindCacheEnabled(conf.Carbonserver.FindCacheEnabled)
 		carbonserver.SetQueryCacheSizeMB(conf.Carbonserver.QueryCacheSizeMB)
 		carbonserver.SetTrigramIndex(conf.Carbonserver.TrigramIndex)
+		carbonserver.SetGraphiteWeb10(conf.Carbonserver.GraphiteWeb10StrictMode)
 		// carbonserver.SetQueryTimeout(conf.Carbonserver.QueryTimeout.Value())
 
 		if err = carbonserver.Listen(conf.Carbonserver.Listen); err != nil {

--- a/carbon/app.go
+++ b/carbon/app.go
@@ -314,6 +314,7 @@ func (app *App) Start() (err error) {
 		carbonserver.SetQueryCacheEnabled(conf.Carbonserver.QueryCacheEnabled)
 		carbonserver.SetFindCacheEnabled(conf.Carbonserver.FindCacheEnabled)
 		carbonserver.SetQueryCacheSizeMB(conf.Carbonserver.QueryCacheSizeMB)
+		carbonserver.SetTrigramIndex(conf.Carbonserver.TrigramIndex)
 		// carbonserver.SetQueryTimeout(conf.Carbonserver.QueryTimeout.Value())
 
 		if err = carbonserver.Listen(conf.Carbonserver.Listen); err != nil {

--- a/carbon/config.go
+++ b/carbon/config.go
@@ -106,6 +106,7 @@ type carbonserverConfig struct {
 	Buckets           int       `toml:"buckets"`
 	MaxGlobs          int       `toml:"max-globs"`
 	MetricsAsCounters bool      `toml:"metrics-as-counters"`
+	TrigramIndex      bool      `toml:"trigram-index"`
 }
 
 type pprofConfig struct {
@@ -200,6 +201,7 @@ func NewConfig() *Config {
 			QueryCacheEnabled: true,
 			QueryCacheSizeMB:  0,
 			FindCacheEnabled:  true,
+			TrigramIndex:      true,
 		},
 		Carbonlink: carbonlinkConfig{
 			Listen:  "127.0.0.1:7002",

--- a/carbon/config.go
+++ b/carbon/config.go
@@ -94,19 +94,20 @@ type carbonlinkConfig struct {
 }
 
 type carbonserverConfig struct {
-	Listen            string    `toml:"listen"`
-	Enabled           bool      `toml:"enabled"`
-	ReadTimeout       *Duration `toml:"read-timeout"`
-	IdleTimeout       *Duration `toml:"idle-timeout"`
-	WriteTimeout      *Duration `toml:"write-timeout"`
-	ScanFrequency     *Duration `toml:"scan-frequency"`
-	QueryCacheEnabled bool      `toml:"query-cache-enabled"`
-	QueryCacheSizeMB  int       `toml:"query-cache-size-mb"`
-	FindCacheEnabled  bool      `toml:"find-cache-enabled"`
-	Buckets           int       `toml:"buckets"`
-	MaxGlobs          int       `toml:"max-globs"`
-	MetricsAsCounters bool      `toml:"metrics-as-counters"`
-	TrigramIndex      bool      `toml:"trigram-index"`
+	Listen                  string    `toml:"listen"`
+	Enabled                 bool      `toml:"enabled"`
+	ReadTimeout             *Duration `toml:"read-timeout"`
+	IdleTimeout             *Duration `toml:"idle-timeout"`
+	WriteTimeout            *Duration `toml:"write-timeout"`
+	ScanFrequency           *Duration `toml:"scan-frequency"`
+	QueryCacheEnabled       bool      `toml:"query-cache-enabled"`
+	QueryCacheSizeMB        int       `toml:"query-cache-size-mb"`
+	FindCacheEnabled        bool      `toml:"find-cache-enabled"`
+	Buckets                 int       `toml:"buckets"`
+	MaxGlobs                int       `toml:"max-globs"`
+	MetricsAsCounters       bool      `toml:"metrics-as-counters"`
+	TrigramIndex            bool      `toml:"trigram-index"`
+	GraphiteWeb10StrictMode bool      `toml:"graphtie-web-10-strict-mode"`
 }
 
 type pprofConfig struct {
@@ -198,10 +199,11 @@ func NewConfig() *Config {
 			WriteTimeout: &Duration{
 				Duration: 60 * time.Second,
 			},
-			QueryCacheEnabled: true,
-			QueryCacheSizeMB:  0,
-			FindCacheEnabled:  true,
-			TrigramIndex:      true,
+			QueryCacheEnabled:       true,
+			QueryCacheSizeMB:        0,
+			FindCacheEnabled:        true,
+			TrigramIndex:            true,
+			GraphiteWeb10StrictMode: true,
 		},
 		Carbonlink: carbonlinkConfig{
 			Listen:  "127.0.0.1:7002",


### PR DESCRIPTION
* Adds an option to disable trigram index (that's more clear than setting scan-interval to 0)
* Fallback to Filesystem-based scan if there is no metrics at all in trigram index.
* Update changelog
* Update readme