### PR TITLE
carbonserver: don't copy RDTime for deleted metrics

### DIFF
--- a/carbonserver/carbonserver.go
+++ b/carbonserver/carbonserver.go
@@ -414,7 +414,9 @@ func (listener *CarbonserverListener) updateFileList(dir string) {
 		}
 
 		for m := range fidx.accessedMetrics {
-			details[m].RdTime = fidx.details[m].RdTime
+			if d, ok := details[m]; ok {
+				d.RdTime = fidx.details[m].RdTime
+			}
 		}
 		fidx.Unlock()
 	}


### PR DESCRIPTION
Fixes #179