### PR TITLE
Calculate response time percentiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,6 +242,8 @@ max-globs = 100
 graphite-web-10-strict-mode = true
 # Allows to keep track for "last time readed" between restarts, leave empty to disable
 internal-stats-dir = ""
+# Calculate /render request time percentiles for the bucket, '95' means calculate 95th Percentile. To disable this feature, leave the list blank
+stats-percentiles = [99, 98, 95, 75, 50]
 
 [dump]
 # Enable dump/restore function on USR2 signal

--- a/carbon/app.go
+++ b/carbon/app.go
@@ -345,6 +345,7 @@ func (app *App) Start() (err error) {
 		carbonserver.SetTrigramIndex(conf.Carbonserver.TrigramIndex)
 		carbonserver.SetGraphiteWeb10(conf.Carbonserver.GraphiteWeb10StrictMode)
 		carbonserver.SetInternalStatsDir(conf.Carbonserver.InternalStatsDir)
+		carbonserver.SetPercentiles(conf.Carbonserver.Percentiles)
 		// carbonserver.SetQueryTimeout(conf.Carbonserver.QueryTimeout.Value())
 
 		if err = carbonserver.Listen(conf.Carbonserver.Listen); err != nil {

--- a/carbon/config.go
+++ b/carbon/config.go
@@ -95,6 +95,7 @@ type carbonserverConfig struct {
 	TrigramIndex            bool      `toml:"trigram-index"`
 	GraphiteWeb10StrictMode bool      `toml:"graphite-web-10-strict-mode"`
 	InternalStatsDir        string    `toml:"internal-stats-dir"`
+	Percentiles             []int     `toml:"stats-percentiles"`
 }
 
 type pprofConfig struct {

--- a/deploy/go-carbon.conf
+++ b/deploy/go-carbon.conf
@@ -176,6 +176,8 @@ max-globs = 100
 graphite-web-10-strict-mode = true
 # Allows to keep track for "last time readed" between restarts, leave empty to disable
 internal-stats-dir = ""
+# Calculate /render request time percentiles for the bucket, '95' means calculate 95th Percentile. To disable this feature, leave the list blank
+stats-percentiles = [99, 98, 95, 75, 50]
 
 [dump]
 # Enable dump/restore function on USR2 signal


### PR DESCRIPTION
Naive approach - store all response time for /render handler in a slice.
Then calculate percentiles.