### PR TITLE
go-carbon: export config and build tag as expvar if pprof is enabled

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,7 @@ GO ?= go
 export GOPATH := $(CURDIR)/_vendor
 TEMPDIR:=$(shell mktemp -d)
 VERSION:=$(shell sh -c 'grep "const Version" $(NAME).go  | cut -d\" -f2')
+BUILD ?= $(shell git describe --abbrev=4 --dirty --always --tags)
 
 all: $(NAME)
 
@@ -15,7 +16,7 @@ submodules:
 	git submodule update --init --recursive
 
 $(NAME):
-	$(GO) build $(MODULE)
+	$(GO) build --ldflags '-X main.BuildVersion=$(BUILD)' $(MODULE)
 
 run-test:
 	$(GO) $(COMMAND) $(MODULE)

--- a/go-carbon.go
+++ b/go-carbon.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"expvar"
 	"flag"
 	"fmt"
 	"log"
@@ -25,6 +26,8 @@ import (
 
 // Version of go-carbon
 const Version = "0.10.1"
+
+var BuildVersion = "(development version)"
 
 func httpServe(addr string) (func(), error) {
 	tcpAddr, err := net.ResolveTCPAddr("tcp", addr)
@@ -160,6 +163,10 @@ func main() {
 		if err != nil {
 			mainLogger.Fatal(err.Error())
 		}
+
+		expvar.NewString("GoVersion").Set(runtime.Version())
+		expvar.NewString("BuildVersion").Set(BuildVersion)
+		expvar.Publish("Config", expvar.Func(func() interface{} { return cfg }))
 	}
 
 	if err = app.Start(); err != nil {


### PR DESCRIPTION
This will give visibility on:
 1. Version of Go that was used to build the binary
 2. Config that go-carbon is using
 3. Actual version and tag that was used to build go-carbon