### PR TITLE
carbonserver: optionally fail on max-globs exhaust

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,6 +243,8 @@ scan-frequency = "5m0s"
 # This value is used to speed-up /find requests with
 # a lot of globs, but will lead to increased memory consumption
 max-globs = 100
+# Fail if amount of globs more than max-globs
+fail-on-max-globs = false
 # graphite-web-10-mode
 # Use Graphite-web 1.0 native structs for pickle response
 # This mode will break compatibility with graphite-web 0.9.x

--- a/carbon/app.go
+++ b/carbon/app.go
@@ -359,6 +359,7 @@ func (app *App) Start() (err error) {
 		carbonserver := carbonserver.NewCarbonserverListener(core.Get)
 		carbonserver.SetWhisperData(conf.Whisper.DataDir)
 		carbonserver.SetMaxGlobs(conf.Carbonserver.MaxGlobs)
+		carbonserver.SetFailOnMaxGlobs(conf.Carbonserver.FailOnMaxGlobs)
 		carbonserver.SetBuckets(conf.Carbonserver.Buckets)
 		carbonserver.SetMetricsAsCounters(conf.Carbonserver.MetricsAsCounters)
 		carbonserver.SetScanFrequency(conf.Carbonserver.ScanFrequency.Value())

--- a/carbon/config.go
+++ b/carbon/config.go
@@ -96,6 +96,7 @@ type carbonserverConfig struct {
 	FindCacheEnabled        bool      `toml:"find-cache-enabled"`
 	Buckets                 int       `toml:"buckets"`
 	MaxGlobs                int       `toml:"max-globs"`
+	FailOnMaxGlobs          bool      `toml:"fail-on-max-globs"`
 	MetricsAsCounters       bool      `toml:"metrics-as-counters"`
 	TrigramIndex            bool      `toml:"trigram-index"`
 	GraphiteWeb10StrictMode bool      `toml:"graphite-web-10-strict-mode"`
@@ -170,6 +171,7 @@ func NewConfig() *Config {
 			Enabled:           false,
 			Buckets:           10,
 			MaxGlobs:          100,
+			FailOnMaxGlobs:    false,
 			MetricsAsCounters: false,
 			ScanFrequency: &Duration{
 				Duration: 300 * time.Second,

--- a/deploy/go-carbon.conf
+++ b/deploy/go-carbon.conf
@@ -174,6 +174,8 @@ scan-frequency = "5m0s"
 # This value is used to speed-up /find requests with
 # a lot of globs, but will lead to increased memory consumption
 max-globs = 100
+# Fail if amount of globs more than max-globs
+fail-on-max-globs = 100
 # graphite-web-10-mode
 # Use Graphite-web 1.0 native structs for pickle response
 # This mode will break compatibility with graphite-web 0.9.x


### PR DESCRIPTION
Now if your request exhausts max-globs, you'll get partial response

Add an option to fail on such requests with err=500