### PR TITLE
tcp receiver: update deadline only if previous read took more than ha…

### DIFF
--- a/receiver/tcp/tcp.go
+++ b/receiver/tcp/tcp.go
@@ -187,8 +187,16 @@ func (rcv *TCP) HandleConnection(conn net.Conn) {
 		}
 	})
 
+	lastDeadline := time.Now()
+	readTimeout := 2 * time.Minute
+	conn.SetReadDeadline(lastDeadline.Add(readTimeout))
+
 	for {
-		conn.SetReadDeadline(time.Now().Add(2 * time.Minute))
+		now := time.Now()
+		if now.Sub(lastDeadline) > (readTimeout / 4) {
+			conn.SetReadDeadline(now.Add(readTimeout))
+			lastDeadline = now
+		}
 
 		line, err := reader.ReadBytes('\n')
 


### PR DESCRIPTION
…lf of allowed time

This dramatically reduces lock contention on setting new deadline and shouldn't be harmful,
considering that normal metric size is sub-MB.

This optimization should allow receiver to handle more than 1kk points/sec for a single connection.