### PR TITLE
Change sysconfig to use $NAME variable rather than undefined $prog

### DIFF
--- a/deploy/go-carbon.init
+++ b/deploy/go-carbon.init
@@ -21,8 +21,8 @@ if [ -f /etc/rc.d/init.d/functions ]; then
   . /etc/rc.d/init.d/functions
 fi
 
-if [ -f /etc/sysconfig/$prog ]; then
-   . /etc/sysconfig/$prog
+if [ -f /etc/sysconfig/$NAME ]; then
+   . /etc/sysconfig/$NAME
 fi
 
 ARGS="-config $CONFIG -pidfile $PIDFILE -daemon"


### PR DESCRIPTION
The init script has support for /etc/sysconfig but was using an
uninitialized variable $prog. $NAME is already set and designed for
this purpose, so convert to use that.