### PR TITLE
FreeBSD compatibility

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -135,7 +135,7 @@
 	url = https://github.com/rcrowley/go-metrics
 [submodule "vendor/github.com/davecgh/go-spew"]
 	path = vendor/github.com/davecgh/go-spew
-	url = https://github.com/davecgh/go-spew/
+	url = https://github.com/davecgh/go-spew
 [submodule "vendor/github.com/eapache/go-resiliency"]
 	path = vendor/github.com/eapache/go-resiliency
 	url = https://github.com/eapache/go-resiliency

--- a/carbonserver/carbonserver.go
+++ b/carbonserver/carbonserver.go
@@ -472,7 +472,10 @@ func (listener *CarbonserverListener) updateFileList(dir string) {
 		return
 	}
 
-	freeSpace := stat.Bavail * uint64(stat.Bsize)
+	var freeSpace uint64
+	if stat.Bavail >= 0 {
+		freeSpace = uint64(stat.Bavail) * uint64(stat.Bsize)
+	}
 	totalSpace := stat.Blocks * uint64(stat.Bsize)
 
 	fileScanRuntime := time.Since(t0)


### PR DESCRIPTION
> $ go version
> go version go1.9.2 freebsd/amd64
> $ uname -a
> FreeBSD wintermute.skunkwerks.at FreeBSD 12.0-CURRENT 
> $ git --version
> git version 2.15.1

I needed 2 changes to compile successfully here:

- trailing / on the .gitmodules causes checkout to fail, possibly only on certain versions of git
- `Bavail` can be negative on some systems and therefore has a `int64` type at least here

This is my first go code ever so I hope it's OK :-)
