### PR TITLE
google pubsub gzip compression, and pubsub.ReceiverSettings

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,12 +224,21 @@ buffer-size = 0
 #
 # [receiver.pubsub]
 # # This receiver receives data from Google PubSub
-# # Authentication is managed through APPLICATION_DEFAULT_CREDENTIALS:
-# # - https://cloud.google.com/docs/authentication/production#providing_credentials_to_your_application
-# # Currently the subscription must exist before running go-carbon.
+# # - Authentication is managed through APPLICATION_DEFAULT_CREDENTIALS:
+# #   - https://cloud.google.com/docs/authentication/production#providing_credentials_to_your_application
+# # - Currently the subscription must exist before running go-carbon.
+# # - The "receiver_*" settings are optional and directly map to the google pubsub
+# #   libraries ReceiveSettings (https://godoc.org/cloud.google.com/go/pubsub#ReceiveSettings)
+# #   - How to think about the "receiver_*" settings: In an attempt to maximize throughput the
+# #     pubsub library will spawn 'receiver_go_routines' to fetch messages from the server.
+# #     These goroutines simply buffer them into memory until 'receiver_max_messages' or 'receiver_max_bytes'
+# #     have been read. This does not affect the actual handling of these messages which are processed by other goroutines.
 # protocol = "pubsub"
 # project = "project-name"
 # subscription = "subscription-name"
+# receiver_go_routines = 4
+# receiver_max_messages = 1000
+# receiver_max_bytes = 500000000 # default 500MB
 
 [carbonlink]
 listen = "127.0.0.1:7002"
@@ -416,6 +425,9 @@ With settings above applied, best write-strategy to use is "noop"
 protocol = "pubsub"
 project = "project-name"
 subscription = "subscription-name"
+# receiver_go_routines = 4
+# receiver_max_messages = 1000
+# receiver_max_bytes = 500000000 # default 500MB
 ```
 
 ##### version 0.11.0

--- a/deploy/go-carbon.conf
+++ b/deploy/go-carbon.conf
@@ -144,6 +144,24 @@ buffer-size = 0
 # #   0.11.0.0
 # #   1.0.0
 # kafka-version = "0.11.0.0"
+#
+# [receiver.pubsub]
+# # This receiver receives data from Google PubSub
+# # - Authentication is managed through APPLICATION_DEFAULT_CREDENTIALS:
+# #   - https://cloud.google.com/docs/authentication/production#providing_credentials_to_your_application
+# # - Currently the subscription must exist before running go-carbon.
+# # - The "receiver_*" settings are optional and directly map to the google pubsub
+# #   libraries ReceiveSettings (https://godoc.org/cloud.google.com/go/pubsub#ReceiveSettings)
+# #   - How to think about the "receiver_*" settings: In an attempt to maximize throughput the
+# #     pubsub library will spawn 'receiver_go_routines' to fetch messages from the server.
+# #     These goroutines simply buffer them into memory until 'receiver_max_messages' or 'receiver_max_bytes'
+# #     have been read. This does not affect the actual handling of these messages which are processed by other goroutines.
+# protocol = "pubsub"
+# project = "project-name"
+# subscription = "subscription-name"
+# receiver_go_routines = 4
+# receiver_max_messages = 1000
+# receiver_max_bytes = 500000000 # default 500MB
 
 [carbonlink]
 listen = "127.0.0.1:7002"

--- a/receiver/pubsub/pubsub.go
+++ b/receiver/pubsub/pubsub.go
@@ -1,8 +1,13 @@
 package pubsub
 
 import (
+	"bytes"
+	"compress/gzip"
 	"context"
 	"fmt"
+	"io"
+	"io/ioutil"
+	"sync"
 	"sync/atomic"
 
 	"cloud.google.com/go/pubsub"
@@ -14,6 +19,10 @@ import (
 	"github.com/lomik/go-carbon/receiver/parse"
 	"github.com/lomik/zapwriter"
 )
+
+// gzipPool provides a sync.Pool of initialized gzip.Readers's to avoid
+// the allocation overhead of repeatedly calling gzip.NewReader
+var gzipPool sync.Pool
 
 func init() {
 	receiver.Register(
@@ -133,25 +142,51 @@ func newPubSub(client *pubsub.Client, name string, options *Options, store func(
 func (rcv *PubSub) handleMessage(m *pubsub.Message) {
 	atomic.AddUint32(&rcv.messagesReceived, 1)
 
-	var data []*points.Points
+	var data []byte
 	var err error
+	var points []*points.Points
+
+	switch m.Attributes["codec"] {
+	case "gzip":
+		gzr, err := acquireGzipReader(bytes.NewBuffer(m.Data))
+		if err != nil {
+			rcv.logger.Error(err.Error())
+			atomic.AddUint32(&rcv.errors, 1)
+			return
+		}
+		defer releaseGzipReader(gzr)
+
+		data, err = ioutil.ReadAll(gzr)
+		if err != nil {
+			rcv.logger.Error(err.Error())
+			atomic.AddUint32(&rcv.errors, 1)
+			return
+		}
+	default:
+		// "none", no compression
+		data = m.Data
+	}
 
 	switch m.Attributes["content-type"] {
 	case "application/python-pickle":
-		data, err = parse.Pickle(m.Data)
+		points, err = parse.Pickle(data)
 	case "application/protobuf":
-		data, err = parse.Protobuf(m.Data)
+		points, err = parse.Protobuf(data)
 	default:
-		data, err = parse.Plain(m.Data)
+		points, err = parse.Plain(data)
 	}
 	if err != nil {
 		atomic.AddUint32(&rcv.errors, 1)
+		rcv.logger.Error(err.Error())
+	}
+	if len(points) == 0 {
 		return
 	}
+
 	cnt := 0
-	for i := 0; i < len(data); i++ {
-		cnt += len(data[i].Data)
-		rcv.out(data[i])
+	for i := 0; i < len(points); i++ {
+		cnt += len(points[i].Data)
+		rcv.out(points[i])
 	}
 	atomic.AddUint32(&rcv.metricsReceived, uint32(cnt))
 }
@@ -179,4 +214,25 @@ func (rcv *PubSub) Stat(send helper.StatCallback) {
 		atomic.AddUint32(&rcv.metricsReceived, -metricsReceived)
 		atomic.AddUint32(&rcv.errors, -errors)
 	}
+}
+
+// acquireGzipReader retrieves a (possibly) pre-initialized gzip.Reader from
+// the package gzipPool (sync.Pool). This reduces memory allocation overhead by re-using
+// gzip.Readers
+func acquireGzipReader(r io.Reader) (*gzip.Reader, error) {
+	v := gzipPool.Get()
+	if v == nil {
+		return gzip.NewReader(r)
+	}
+	zr := v.(*gzip.Reader)
+	if err := zr.Reset(r); err != nil {
+		return nil, err
+	}
+	return zr, nil
+}
+
+// releaseGzipReader returns a gzip.Reader to the package gzipPool
+func releaseGzipReader(zr *gzip.Reader) {
+	zr.Close()
+	gzipPool.Put(zr)
 }


### PR DESCRIPTION
This PR adds two updates to the google pubsub support:

- https://github.com/lomik/go-carbon/commit/c4ea9a88f63c248281962d4fb40f566d661262bd Exposes the pubsub libraries [ReceiverSettings](https://godoc.org/cloud.google.com/go/pubsub#ReceiveSettings). I found this was necessary in benchmarking to achieve maximum throughput. Primarily, the num-go-routines at 4 instead of the default 1 was helpful in keeping go-carbon's buffer of messages full.

- https://github.com/lomik/go-carbon/commit/e9fda9603014383199896a7c8989beede4cb1d3c adds support for compressed pubsub message payloads. The codec is specified on the `codec` attribute of messages. Current values are either `none` (no compression) or `gzip`. Because google pubsub charges by the GB this makes a lot of sense. I also noted significant throughput improvements during load-testing with carbon-relay-ng(code from this PR: https://github.com/graphite-ng/carbon-relay-ng/pull/256)