### PR TITLE
[WIP] added hashfilename support for tagged metrics

### DIFF
--- a/carbon/app.go
+++ b/carbon/app.go
@@ -260,6 +260,7 @@ func (app *App) startPersister() {
 		p.SetSparse(app.Config.Whisper.Sparse)
 		p.SetFLock(app.Config.Whisper.FLock)
 		p.SetWorkers(app.Config.Whisper.Workers)
+		p.SetHashFilenames(app.Config.Whisper.HashFilenames)
 
 		if app.Tags != nil {
 			p.SetTagsEnabled(true)

--- a/carbon/config.go
+++ b/carbon/config.go
@@ -61,6 +61,7 @@ type whisperConfig struct {
 	Sparse              bool   `toml:"sparse-create"`
 	FLock               bool   `toml:"flock"`
 	Enabled             bool   `toml:"enabled"`
+	HashFilenames       bool   `toml:"hash-filenames"`
 	Schemas             persister.WhisperSchemas
 	Aggregation         *persister.WhisperAggregation
 }
@@ -169,6 +170,7 @@ func NewConfig() *Config {
 			Workers:             1,
 			Sparse:              false,
 			FLock:               false,
+			HashFilenames:       true,
 		},
 		Cache: cacheConfig{
 			MaxSize:       1000000,

--- a/persister/whisper.go
+++ b/persister/whisper.go
@@ -37,6 +37,7 @@ type Whisper struct {
 	created             uint32 // counter
 	sparse              bool
 	flock               bool
+	hashFilenames       bool
 	maxUpdatesPerSecond int
 	throttleTicker      *ThrottleTicker
 	storeMutex          [storeMutexCount]sync.Mutex
@@ -99,6 +100,10 @@ func (p *Whisper) SetFLock(flock bool) {
 	p.flock = flock
 }
 
+func (p *Whisper) SetHashFilenames(v bool) {
+	p.hashFilenames = v
+}
+
 func (p *Whisper) SetMockStore(fn func() (StoreFunc, func())) {
 	p.mockStore = fn
 }
@@ -132,7 +137,7 @@ func store(p *Whisper, values *points.Points) {
 
 	var path string
 	if p.tagsEnabled && strings.IndexByte(values.Metric, ';') >= 0 {
-		path = tags.FilePath(p.rootPath, values.Metric) + ".wsp"
+		path = tags.FilePath(p.rootPath, values.Metric, p.hashFilenames) + ".wsp"
 	} else {
 		path = filepath.Join(p.rootPath, strings.Replace(values.Metric, ".", "/", -1)+".wsp")
 	}

--- a/tags/normalize.go
+++ b/tags/normalize.go
@@ -98,8 +98,12 @@ func Normalize(s string) (string, error) {
 	return strings.Join(arr[:len(arr)-toDel], ";"), nil
 }
 
-func FilePath(root string, s string) string {
+func FilePath(root string, s string, hash_only bool) string {
 	sum := sha256.Sum256([]byte(s))
-	prefix := fmt.Sprintf("%x", sum[:3])
-	return filepath.Join(root, "_tagged", prefix[:3], prefix[3:], strings.Replace(s, ".", "_DOT_", -1))
+	hash := fmt.Sprintf("%x", sum)
+	if hash_only == true {
+		return filepath.Join(root, "_tagged", hash[:3], hash[3:6], hash)
+	} else {
+		return filepath.Join(root, "_tagged", hash[:3], hash[3:6],  strings.Replace(s, ".", "_DOT_", -1))
+	}
 }

--- a/tags/normalize_test.go
+++ b/tags/normalize_test.go
@@ -55,8 +55,14 @@ func TestNormalize(t *testing.T) {
 
 func TestFilePath(t *testing.T) {
 	assert := assert.New(t)
-	p := FilePath("/data/", "some.metric;tag1=value2;tag2=value.2")
+	p := FilePath("/data/", "some.metric;tag1=value2;tag2=value.2", false)
 	assert.Equal("/data/_tagged/eff/aae/some_DOT_metric;tag1=value2;tag2=value_DOT_2", p)
+}
+
+func TestFilePathHashed(t *testing.T) {
+	assert := assert.New(t)
+	p := FilePath("/data/", "some.metric;tag1=value2;tag2=value.2", true)
+	assert.Equal("/data/_tagged/eff/aae/effaae5b55950b150a7493d2f5430772ca2460bf7cccb4d9e523643df54c010f", p)
 }
 
 func BenchmarkNormalizeOriginal(b *testing.B) {
@@ -82,7 +88,7 @@ func BenchmarkFilePath(b *testing.B) {
 	var x string
 
 	for i := 0; i < b.N; i++ {
-		x = FilePath("/data", m)
+		x = FilePath("/data", m, false)
 	}
 
 	if len(x) < 0 {


### PR DESCRIPTION
The tag implementation in Carbon Classic has a bug related to the filename length that is generated for each metric; because the entire metric and labelset are concatenated together, the filename can exceed 255 characters, which is the max filename length on most operating systems. This is a implementation for go-carbon of the same fix that the Graphite team is planning to do.

See https://github.com/graphite-project/graphite-web/issues/2219, https://github.com/graphite-project/carbon/pull/743, https://github.com/graphite-project/graphite-web/pull/2221 for more details.

This should not be merged in until after the Graphite team has merged their changes in and this change has been re-validated against the updated implementation, if any.
