### PR TITLE
Fix info handler not returning numberOfPoints in Retentions

### DIFF
--- a/carbonserver/info.go
+++ b/carbonserver/info.go
@@ -8,8 +8,6 @@ import (
 	"strings"
 	"sync/atomic"
 	"time"
-	"unsafe"
-
 	"go.uber.org/zap"
 
 	"github.com/go-graphite/go-whisper"
@@ -19,9 +17,6 @@ import (
 	protov3 "github.com/go-graphite/protocol/carbonapi_v3_pb"
 )
 
-func retentionsV3toV2(ptr *[]protov3.Retention) *[]protov2.Retention {
-	return (*[]protov2.Retention)(unsafe.Pointer(ptr))
-}
 
 func (listener *CarbonserverListener) infoHandler(wr http.ResponseWriter, req *http.Request) {
 	// URL: /info/?target=the.metric.Name&format=json
@@ -88,7 +83,8 @@ func (listener *CarbonserverListener) infoHandler(wr http.ResponseWriter, req *h
 	)
 
 	response := protov3.MultiMetricsInfoResponse{}
-	for _, metric := range metrics {
+	var retentionsV2 []protov2.Retention
+	for i, metric := range metrics {
 		path := listener.whisperData + "/" + strings.Replace(metric, ".", "/", -1) + ".wsp"
 		w, err := whisper.Open(path)
 
@@ -117,6 +113,14 @@ func (listener *CarbonserverListener) infoHandler(wr http.ResponseWriter, req *h
 				SecondsPerPoint: spp,
 				NumberOfPoints:  nop,
 			})
+			//only one metric is enough - first metric
+			//TODO include support for multiple metrics
+			if i == 0 {
+				retentionsV2 = append(retentionsV2, protov2.Retention{
+					SecondsPerPoint: int32(retention.SecondsPerPoint()),
+					NumberOfPoints:  int32(retention.NumberOfPoints()),
+				})
+			}
 		}
 
 		response.Metrics = append(response.Metrics, protov3.MetricsInfoResponse{
@@ -135,12 +139,8 @@ func (listener *CarbonserverListener) infoHandler(wr http.ResponseWriter, req *h
 	case jsonFormat:
 		contentType = httpHeaders.ContentTypeJSON
 		b, err = json.Marshal(response)
-	case protoV2Format, protoV3Format:
-		if formatCode == protoV3Format {
-			contentType = httpHeaders.ContentTypeCarbonAPIv3PB
-		} else {
-			contentType = httpHeaders.ContentTypeCarbonAPIv2PB
-		}
+	case protoV2Format:
+		contentType = httpHeaders.ContentTypeCarbonAPIv2PB
 
 		var r protov3.MetricsInfoResponse
 		if len(response.Metrics) > 0 {
@@ -152,8 +152,11 @@ func (listener *CarbonserverListener) infoHandler(wr http.ResponseWriter, req *h
 			AggregationMethod: r.ConsolidationFunc,
 			MaxRetention:      int32(r.MaxRetention),
 			XFilesFactor:      r.XFilesFactor,
-			Retentions:        *retentionsV3toV2(&r.Retentions),
+			Retentions:        retentionsV2,
 		}
+		b, err = response.Marshal()
+	case protoV3Format:
+		contentType = httpHeaders.ContentTypeCarbonAPIv3PB
 		b, err = response.Marshal()
 	}
 

--- a/carbonserver/info.go
+++ b/carbonserver/info.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"sync/atomic"
 	"time"
+
 	"go.uber.org/zap"
 
 	"github.com/go-graphite/go-whisper"
@@ -16,7 +17,6 @@ import (
 	protov2 "github.com/go-graphite/protocol/carbonapi_v2_pb"
 	protov3 "github.com/go-graphite/protocol/carbonapi_v3_pb"
 )
-
 
 func (listener *CarbonserverListener) infoHandler(wr http.ResponseWriter, req *http.Request) {
 	// URL: /info/?target=the.metric.Name&format=json
@@ -115,7 +115,7 @@ func (listener *CarbonserverListener) infoHandler(wr http.ResponseWriter, req *h
 			})
 			//only one metric is enough - first metric
 			//TODO include support for multiple metrics
-			if i == 0 {
+			if i == 0 && formatCode == protoV2Format {
 				retentionsV2 = append(retentionsV2, protov2.Retention{
 					SecondsPerPoint: int32(retention.SecondsPerPoint()),
 					NumberOfPoints:  int32(retention.NumberOfPoints()),


### PR DESCRIPTION
Due to incomaptible type conversion between retention protocols v2 and v3, numberOfPoints was becoming 0. 
https://play.golang.org/p/zUJrIyB9792

Fix uses retention of first metric to construct v2 response, rather than trying to convert v3 to v2.