### PR TITLE
Hard max creates per second

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,12 +9,14 @@ TEMPDIR:=$(shell mktemp -d)
 VERSION:=$(shell sh -c 'grep "const Version" $(NAME).go  | cut -d\" -f2')
 BUILD ?= $(shell git describe --abbrev=4 --dirty --always --tags)
 
+SOURCES=$(shell find . -name "*.go")
+
 all: $(NAME)
 
-$(NAME):
+$(NAME): $(SOURCES)
 	$(GO) build --ldflags '-X main.BuildVersion=$(BUILD)' $(MODULE)
 
-debug:
+debug: $(SOURCES)
 	$(GO) build -gcflags=all='-l -N' $(MODULE)
 
 run-test:

--- a/README.md
+++ b/README.md
@@ -98,6 +98,8 @@ workers = 8
 max-updates-per-second = 0
 # Softly limits the number of whisper files that get created each second. 0 - no limit
 max-creates-per-second = 0
+# Make max-creates-per-second a hard limit. Extra new metrics are dropped. A hard throttle of 0 drops all new metrics.
+hard-max-creates-per-second = false
 # Sparse file creation
 sparse-create = false
 # use flock on every file call (ensures consistency if there are concurrent read/writes to the same file)

--- a/carbon/app.go
+++ b/carbon/app.go
@@ -260,6 +260,7 @@ func (app *App) startPersister() {
 		)
 		p.SetMaxUpdatesPerSecond(app.Config.Whisper.MaxUpdatesPerSecond)
 		p.SetMaxCreatesPerSecond(app.Config.Whisper.MaxCreatesPerSecond)
+		p.SetHardMaxCreatesPerSecond(app.Config.Whisper.HardMaxCreatesPerSecond)
 		p.SetSparse(app.Config.Whisper.Sparse)
 		p.SetFLock(app.Config.Whisper.FLock)
 		p.SetWorkers(app.Config.Whisper.Workers)

--- a/carbon/config.go
+++ b/carbon/config.go
@@ -53,18 +53,19 @@ type commonConfig struct {
 }
 
 type whisperConfig struct {
-	DataDir             string `toml:"data-dir"`
-	SchemasFilename     string `toml:"schemas-file"`
-	AggregationFilename string `toml:"aggregation-file"`
-	Workers             int    `toml:"workers"`
-	MaxUpdatesPerSecond int    `toml:"max-updates-per-second"`
-	MaxCreatesPerSecond int    `toml:"max-creates-per-second"`
-	Sparse              bool   `toml:"sparse-create"`
-	FLock               bool   `toml:"flock"`
-	Enabled             bool   `toml:"enabled"`
-	HashFilenames       bool   `toml:"hash-filenames"`
-	Schemas             persister.WhisperSchemas
-	Aggregation         *persister.WhisperAggregation
+	DataDir                 string `toml:"data-dir"`
+	SchemasFilename         string `toml:"schemas-file"`
+	AggregationFilename     string `toml:"aggregation-file"`
+	Workers                 int    `toml:"workers"`
+	MaxUpdatesPerSecond     int    `toml:"max-updates-per-second"`
+	MaxCreatesPerSecond     int    `toml:"max-creates-per-second"`
+	HardMaxCreatesPerSecond bool   `toml:"hard-max-creates-per-second"`
+	Sparse                  bool   `toml:"sparse-create"`
+	FLock                   bool   `toml:"flock"`
+	Enabled                 bool   `toml:"enabled"`
+	HashFilenames           bool   `toml:"hash-filenames"`
+	Schemas                 persister.WhisperSchemas
+	Aggregation             *persister.WhisperAggregation
 }
 
 type cacheConfig struct {

--- a/carbonserver/render.go
+++ b/carbonserver/render.go
@@ -40,6 +40,22 @@ type timeRange struct {
 	until int32
 }
 
+func getTargetNames(targets map[timeRange][]target) []string {
+	c := 0
+	for _, v := range targets {
+		c += len(v)
+	}
+
+	names := make([]string, 0, c)
+	for _, v := range targets {
+		for _, t := range v {
+			names = append(names, t.Name)
+		}
+	}
+
+	return names
+}
+
 func stringToInt32(t string) (int32, error) {
 	i, err := strconv.Atoi(t)
 
@@ -162,15 +178,16 @@ func (listener *CarbonserverListener) renderHandler(wr http.ResponseWriter, req 
 		return
 	}
 
+	tgs := getTargetNames(targets)
 	accessLogger = accessLogger.With(
-		zap.Any("targets", targets),
+		zap.Strings("targets", tgs),
 	)
 
 	logger := TraceContextToZap(ctx, listener.accessLogger.With(
 		zap.String("handler", "render"),
 		zap.String("url", req.URL.RequestURI()),
 		zap.String("peer", req.RemoteAddr),
-		zap.Any("targets", targets),
+		zap.Strings("targets", tgs),
 		zap.String("format", format.String()),
 	))
 

--- a/persister/throttle.go
+++ b/persister/throttle.go
@@ -1,17 +1,42 @@
 package persister
 
 import (
+	"context"
 	"time"
 
 	"github.com/lomik/go-carbon/helper"
 )
 
+// ThrottleTicker is a ticker that can be used for hard or soft rate-limiting.
+//
+// * A soft rate limiter will send a message on C at the actual rate that is
+//   specified.
+//
+// * A hard rate limiter may send arbitrarily many messages on C every second,
+//   but it will send the value 'true' with the first ratePerSec ones, and
+//   'false' with all subsequent ones, until the next second. It is up to the
+//   user to decide what to do in each case.
 type ThrottleTicker struct {
 	helper.Stoppable
 	C chan bool
 }
 
+// NewThrottleTicker returns a new soft throttle ticker.
 func NewThrottleTicker(ratePerSec int) *ThrottleTicker {
+	return newThrottleTicker(ratePerSec, false)
+}
+
+// NewSoftThrottleTicker returns a new soft throttle ticker.
+func NewSoftThrottleTicker(ratePerSec int) *ThrottleTicker {
+	return newThrottleTicker(ratePerSec, false)
+}
+
+// NewHardThrottleTicker returns a new hard throttle ticker.
+func NewHardThrottleTicker(ratePerSec int) *ThrottleTicker {
+	return newThrottleTicker(ratePerSec, true)
+}
+
+func newThrottleTicker(ratePerSec int, hard bool) *ThrottleTicker {
 	t := &ThrottleTicker{
 		C: make(chan bool, ratePerSec),
 	}
@@ -23,8 +48,18 @@ func NewThrottleTicker(ratePerSec int) *ThrottleTicker {
 		return t
 	}
 
-	t.Go(func(exit chan bool) {
-		defer close(t.C)
+	if hard {
+		t.Go(hardThrottle(t.C, ratePerSec))
+	} else {
+		t.Go(softThrottle(t.C, ratePerSec))
+	}
+
+	return t
+}
+
+func softThrottle(throttle chan bool, ratePerSec int) func(chan bool) {
+	return func(exit chan bool) {
+		defer close(throttle)
 
 		delimeter := ratePerSec
 		chunk := 1
@@ -53,7 +88,7 @@ func NewThrottleTicker(ratePerSec int) *ThrottleTicker {
 			case <-ticker.C:
 				for i := 0; i < chunk; i++ {
 					select {
-					case t.C <- true:
+					case throttle <- true:
 					//pass
 					case <-exit:
 						break LOOP
@@ -63,7 +98,48 @@ func NewThrottleTicker(ratePerSec int) *ThrottleTicker {
 				break LOOP
 			}
 		}
-	})
+	}
+}
 
-	return t
+func hardThrottle(throttle chan bool, ratePerSec int) func(chan bool) {
+	return func(exit chan bool) {
+		defer close(throttle)
+
+		ticker := time.NewTicker(time.Second)
+		defer ticker.Stop()
+
+		var ctx context.Context
+		var cancel context.CancelFunc = func() {}
+
+		for {
+			select {
+			case <-ticker.C:
+				cancel()
+
+				ctx, cancel = context.WithTimeout(context.Background(), time.Second)
+				go func(ctx context.Context, keepValue chan bool) {
+					c := 0
+					for {
+						select {
+						case <-ctx.Done():
+							return
+						case <-exit:
+							return
+						default:
+							if c < ratePerSec {
+								keepValue <- true
+								c++
+							} else {
+								keepValue <- false
+							}
+						}
+					}
+				}(ctx, throttle)
+
+			case <-exit:
+				cancel()
+				return
+			}
+		}
+	}
 }

--- a/persister/whisper.go
+++ b/persister/whisper.go
@@ -189,11 +189,22 @@ func (p *Whisper) store(metric string) {
 			if !keep {
 				p.pop(metric)
 				atomic.AddUint32(&p.throttledCreates, 1)
+				p.logger.Error("metric creation throttled",
+					zap.String("name", metric),
+					zap.String("operation", "create"),
+					zap.Bool("dropped", true),
+				)
 				return
 			}
+
 			// pass
 		default:
 			atomic.AddUint32(&p.throttledCreates, 1)
+			p.logger.Error("metric creation throttled",
+				zap.String("name", metric),
+				zap.String("operation", "create"),
+				zap.Bool("dropped", false),
+			)
 			return
 		}
 


### PR DESCRIPTION
At a certain scale, it's useful to have the soft max-creates-per-second limit be a hard one. This is added as an option (off by default) in this pull request.

We also fix some logging that had been wonky for a while.