### PR TITLE
carbonserver/render.go: fix invalid pickle response on empty queries

### DIFF
--- a/carbonserver/render.go
+++ b/carbonserver/render.go
@@ -374,7 +374,7 @@ func (listener *CarbonserverListener) prepareDataProto(format responseFormat, ta
 	}
 
 	if format == protoV2Format || format == jsonFormat {
-		if len(multiv2.Metrics) == 0 {
+		if len(multiv2.Metrics) == 0 && format == protoV2Format {
 			return fetchResponse{nil, contentType, 0, 0, 0, nil}, err
 		}
 
@@ -385,7 +385,7 @@ func (listener *CarbonserverListener) prepareDataProto(format responseFormat, ta
 			valuesFetched += len(multiv2.Metrics[i].Values)
 		}
 	} else {
-		if len(multiv3.Metrics) == 0 {
+		if len(multiv3.Metrics) == 0 && format == protoV3Format{
 			return fetchResponse{nil, contentType, 0, 0, 0, nil}, err
 		}
 


### PR DESCRIPTION
Fixes https://github.com/lomik/go-carbon/issues/249.

Hopefully, this does not break anything else. I similarly added a case for JSON format as I realized that we were also sending a `application/text` response rather than a valid empty `application/json` one.