### PR TITLE
carbonserver: support graphite-web's `REMOTE_STORE_USE_POST`

### DIFF
--- a/carbonserver/capability.go
+++ b/carbonserver/capability.go
@@ -29,7 +29,6 @@ func (listener *CarbonserverListener) capabilityHandler(wr http.ResponseWriter, 
 		zap.String("peer", req.RemoteAddr),
 	))
 
-	req.ParseForm()
 	format := req.FormValue("format")
 
 	accepts := req.Header["Accept"]

--- a/carbonserver/details.go
+++ b/carbonserver/details.go
@@ -27,7 +27,6 @@ func (listener *CarbonserverListener) detailsHandler(wr http.ResponseWriter, req
 
 	atomic.AddUint64(&listener.metrics.DetailsRequests, 1)
 
-	req.ParseForm()
 	format := req.FormValue("format")
 
 	accessLogger := TraceContextToZap(ctx, listener.accessLogger.With(

--- a/carbonserver/find.go
+++ b/carbonserver/find.go
@@ -33,7 +33,6 @@ func (listener *CarbonserverListener) findHandler(wr http.ResponseWriter, req *h
 
 	atomic.AddUint64(&listener.metrics.FindRequests, 1)
 
-	req.ParseForm()
 	format := req.FormValue("format")
 	query := req.Form["query"]
 

--- a/carbonserver/info.go
+++ b/carbonserver/info.go
@@ -24,7 +24,7 @@ func (listener *CarbonserverListener) infoHandler(wr http.ResponseWriter, req *h
 	ctx := req.Context()
 
 	atomic.AddUint64(&listener.metrics.InfoRequests, 1)
-	req.ParseForm()
+
 	metrics := req.Form["target"]
 	format := req.FormValue("format")
 

--- a/carbonserver/list.go
+++ b/carbonserver/list.go
@@ -43,7 +43,6 @@ func (listener *CarbonserverListener) listHandler(wr http.ResponseWriter, req *h
 
 	atomic.AddUint64(&listener.metrics.ListRequests, 1)
 
-	req.ParseForm()
 	format := req.FormValue("format")
 
 	accessLogger := TraceContextToZap(ctx, listener.accessLogger.With(

--- a/carbonserver/render.go
+++ b/carbonserver/render.go
@@ -67,8 +67,6 @@ func stringToInt32(t string) (int32, error) {
 }
 
 func getFormat(req *http.Request) (responseFormat, error) {
-	req.ParseForm() // idempotent
-
 	format := req.FormValue("format")
 	if format == "" {
 		format = "json"
@@ -90,8 +88,6 @@ func getFormat(req *http.Request) (responseFormat, error) {
 }
 
 func getTargets(req *http.Request, format responseFormat) (map[timeRange][]target, error) {
-	req.ParseForm() // idempotent
-
 	targets := make(map[timeRange][]target)
 
 	switch format {
@@ -147,8 +143,6 @@ func (listener *CarbonserverListener) renderHandler(wr http.ResponseWriter, req 
 		zap.String("url", req.URL.RequestURI()),
 		zap.String("peer", req.RemoteAddr),
 	))
-
-	req.ParseForm()
 
 	format, err := getFormat(req)
 	if err != nil {


### PR DESCRIPTION
While `Content-Type: application/x-www-form-urlencoded` is supported, graphite-web sends POST requests with `Content-Type: multipart/form-data`.
Because we're explicitly calling `req.ParseForm()`, we are unable to process `multipart/form-data`.
Instead, we should remove `req.ParseForm()` entirely as calls to `FormValue()` automatically call `ParseMultipartForm()` / `ParseForm()` as necessary.

Ref: https://golang.org/pkg/net/http/#Request.FormValue
Fixes https://github.com/lomik/go-carbon/issues/249