### PR TITLE
Correctly disable soft rate limiting

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ $(NAME): $(SOURCES)
 	$(GO) build --ldflags '-X main.BuildVersion=$(BUILD)' $(MODULE)
 
 debug: $(SOURCES)
-	$(GO) build -gcflags=all='-l -N' $(MODULE)
+	$(GO) build -ldflags=-compressdwarf=false -gcflags=all='-l -N' $(MODULE)
 
 run-test:
 	$(GO) $(COMMAND) $(MODULE)

--- a/persister/whisper.go
+++ b/persister/whisper.go
@@ -185,8 +185,8 @@ func (p *Whisper) store(metric string) {
 
 		// max creates throttling
 		select {
-		case keep := <-p.maxCreatesTicker.C:
-			if !keep {
+		case keep, open := <-p.maxCreatesTicker.C:
+			if open && !keep {
 				p.pop(metric)
 				atomic.AddUint32(&p.throttledCreates, 1)
 				p.logger.Error("metric creation throttled",


### PR DESCRIPTION
I'm open to ideas on how to write a regression test for this. I couldn't see how to fit this into the existing throttler tests quickly, but I may have missed something obvious.