### PR TITLE
Reply with 404 when nothing is found

### DIFF
--- a/carbonserver/info.go
+++ b/carbonserver/info.go
@@ -132,6 +132,17 @@ func (listener *CarbonserverListener) infoHandler(wr http.ResponseWriter, req *h
 		})
 	}
 
+	if len(response.Metrics) == 0 {
+		atomic.AddUint64(&listener.metrics.InfoErrors, 1)
+		accessLogger.Error("info failed",
+			zap.String("reason", "Not Found"),
+			zap.Int("http_code", http.StatusNotFound),
+			zap.Error(errorNotFound{}),
+		)
+		http.Error(wr, "Not Found", http.StatusNotFound)
+		return
+	}
+
 	var b []byte
 	var err error
 	contentType := ""
@@ -161,7 +172,7 @@ func (listener *CarbonserverListener) infoHandler(wr http.ResponseWriter, req *h
 	}
 
 	if err != nil {
-		atomic.AddUint64(&listener.metrics.RenderErrors, 1)
+		atomic.AddUint64(&listener.metrics.InfoErrors, 1)
 		accessLogger.Error("info failed",
 			zap.String("reason", "response encode failed"),
 			zap.Int("http_code", http.StatusInternalServerError),


### PR DESCRIPTION
These commits make go-carbon reply with a 404 HTTP status code when it can't find anything in its /render, /find and /info handlers instead of with a 200 code and an empty response. The exception is when we ask the /render handler for data in pickle format, in some attempt at compatibility with the Python stack.

This seems to be an OK use of the 404 code according to [RFC 7231](https://tools.ietf.org/html/rfc7231#section-6.5.4).

The motivation for this is that our request monitoring totally failed to pick up on a recent outage we had, where we managed to kill all our stores with a bad configuration change. Carbonzipper would get no data, and report empty responses with 200 codes to carbonapi. We'll make relevant patches to our end of the stack, but figured it would be fine to patch the entire pipeline.

If we're worried about this breaking backwards compatibility with something, we'd be happy to hide this behind a config option that's disabled by default.