### PR TITLE
Fix broken infoHandler as target was not being parsed.

### DIFF
--- a/carbonserver/info.go
+++ b/carbonserver/info.go
@@ -25,8 +25,8 @@ func (listener *CarbonserverListener) infoHandler(wr http.ResponseWriter, req *h
 
 	atomic.AddUint64(&listener.metrics.InfoRequests, 1)
 
-	metrics := req.Form["target"]
 	format := req.FormValue("format")
+	metrics := req.Form["target"]
 
 	accessLogger := TraceContextToZap(ctx, listener.accessLogger.With(
 		zap.String("handler", "info"),


### PR DESCRIPTION
As per commit 96cfab048c1cc2558982874a7cda66436a2537e2, in order 
to read the multi part form data, FormValue should be called, which
in turn calls ParseForm/ParseMultiForm.
Calling req.Form before req.FormaValue was breaking the info
handler as it was missing the target data.