### PR TITLE
Add ability to re-publish tags at a specific update interval

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,6 +265,7 @@ enabled = false
 # TagDB url. It should support /tags/tagMultiSeries endpoint
 tagdb-url = "http://127.0.0.1:8000"
 tagdb-chunk-size = 32
+tagdb-update-interval = 100
 # Directory for send queue (based on leveldb)
 local-dir = "/var/lib/graphite/tagging/"
 # POST timeout

--- a/carbon/app.go
+++ b/carbon/app.go
@@ -242,10 +242,11 @@ func (app *App) Stop() {
 func (app *App) startPersister() {
 	if app.Config.Tags.Enabled {
 		app.Tags = tags.New(&tags.Options{
-			LocalPath:      app.Config.Tags.LocalDir,
-			TagDB:          app.Config.Tags.TagDB,
-			TagDBTimeout:   app.Config.Tags.TagDBTimeout.Value(),
-			TagDBChunkSize: app.Config.Tags.TagDBChunkSize,
+			LocalPath:           app.Config.Tags.LocalDir,
+			TagDB:               app.Config.Tags.TagDB,
+			TagDBTimeout:        app.Config.Tags.TagDBTimeout.Value(),
+			TagDBChunkSize:      app.Config.Tags.TagDBChunkSize,
+			TagDBUpdateInterval: app.Config.Tags.TagDBUpdateInterval,
 		})
 	}
 
@@ -268,7 +269,7 @@ func (app *App) startPersister() {
 
 		if app.Tags != nil {
 			p.SetTagsEnabled(true)
-			p.SetOnCreateTagged(app.Tags.Add)
+			p.SetTaggedFn(app.Tags.Add)
 		}
 
 		p.Start()

--- a/carbon/config.go
+++ b/carbon/config.go
@@ -89,11 +89,12 @@ type receiverConfig struct {
 }
 
 type tagsConfig struct {
-	Enabled        bool      `toml:"enabled"`
-	TagDB          string    `toml:"tagdb-url"`
-	TagDBTimeout   *Duration `toml:"tagdb-timeout"`
-	TagDBChunkSize int       `toml:"tagdb-chunk-size"`
-	LocalDir       string    `toml:"local-dir"`
+	Enabled             bool      `toml:"enabled"`
+	TagDB               string    `toml:"tagdb-url"`
+	TagDBTimeout        *Duration `toml:"tagdb-timeout"`
+	TagDBChunkSize      int       `toml:"tagdb-chunk-size"`
+	TagDBUpdateInterval uint64    `toml:"tagdb-update-interval"`
+	LocalDir            string    `toml:"local-dir"`
 }
 
 type carbonserverConfig struct {
@@ -221,8 +222,9 @@ func NewConfig() *Config {
 			TagDBTimeout: &Duration{
 				Duration: time.Second,
 			},
-			TagDBChunkSize: 32,
-			LocalDir:       "/var/lib/graphite/tagging/",
+			TagDBChunkSize:      32,
+			TagDBUpdateInterval: 100,
+			LocalDir:            "/var/lib/graphite/tagging/",
 		},
 		Pprof: pprofConfig{
 			Listen:  "127.0.0.1:7007",

--- a/persister/whisper.go
+++ b/persister/whisper.go
@@ -27,8 +27,8 @@ type Whisper struct {
 	recv                    func(chan bool) string
 	pop                     func(string) (*points.Points, bool)
 	confirm                 func(*points.Points)
-	onCreateTagged          func(string)
 	tagsEnabled             bool
+	taggedFn                func(string, bool)
 	schemas                 WhisperSchemas
 	aggregation             *WhisperAggregation
 	workersCount            int
@@ -129,8 +129,8 @@ func (p *Whisper) SetTagsEnabled(v bool) {
 	p.tagsEnabled = v
 }
 
-func (p *Whisper) SetOnCreateTagged(fn func(string)) {
-	p.onCreateTagged = fn
+func (p *Whisper) SetTaggedFn(fn func(string, bool)) {
+	p.taggedFn = fn
 }
 
 func fnv32(key string) uint32 {
@@ -246,8 +246,8 @@ func (p *Whisper) store(metric string) {
 			return
 		}
 
-		if p.tagsEnabled && p.onCreateTagged != nil && strings.IndexByte(metric, ';') >= 0 {
-			p.onCreateTagged(metric)
+		if p.tagsEnabled && p.taggedFn != nil && strings.IndexByte(metric, ';') >= 0 {
+			p.taggedFn(metric, true)
 		}
 
 		p.createLogger.Debug("created",
@@ -280,9 +280,12 @@ func (p *Whisper) store(metric string) {
 
 	// start = time.Now()
 	p.updateMany(w, path, points)
-
 	w.Close()
 	// atomic.AddUint64(&p.blockUpdateManyNs, uint64(time.Since(start).Nanoseconds()))
+
+	if p.tagsEnabled && p.taggedFn != nil && strings.IndexByte(metric, ';') >= 0 {
+		p.taggedFn(metric, false)
+	}
 }
 
 func (p *Whisper) worker(exit chan bool) {


### PR DESCRIPTION
Fixes https://github.com/lomik/go-carbon/issues/256

**TODO**: 
- Items in `updateCounters` must have a (fixed) TTL to keep memory usage somewhat under control (even though the `*uint64` map capacity will never shrink - we can still get the GC to sweep the extra `uint64`) when go-carbon runs for extended periods of time and when the metrics/tags turnover is high; it means we also want to (re-)publish the tags if it's not in the map yet, as updates may be slower than the TTL period and that therefore we would never re-publish 
- Run `gofmt`
