### PR TITLE
Populate metric details and access times only if stats are enabled

### DIFF
--- a/carbonserver/render.go
+++ b/carbonserver/render.go
@@ -230,7 +230,9 @@ func (listener *CarbonserverListener) renderHandler(wr http.ResponseWriter, req 
 		return
 	}
 
-	listener.UpdateMetricsAccessTimesByRequest(response.metrics)
+	if listener.internalStatsDir != "" {
+		listener.UpdateMetricsAccessTimesByRequest(response.metrics)
+	}
 
 	wr.Write(response.data)
 


### PR DESCRIPTION
are enabled. Otherwise, its just a waste of memory and computation.