### PR TITLE
Implement context cancellations for find and find part of render

### DIFF
--- a/carbonserver/carbonserver.go
+++ b/carbonserver/carbonserver.go
@@ -683,7 +683,7 @@ func (listener *CarbonserverListener) updateFileList(dir string) {
 	)
 }
 
-func (listener *CarbonserverListener) expandGlobs(query string, resultCh chan<- *ExpandedGlobResponse, done chan<- struct{}) {
+func (listener *CarbonserverListener) expandGlobs(query string, resultCh chan<- *ExpandedGlobResponse) {
 	var useGlob bool
 	logger := zapwriter.Logger("carbonserver")
 

--- a/carbonserver/carbonserver.go
+++ b/carbonserver/carbonserver.go
@@ -289,6 +289,10 @@ type prometheus struct {
 
 	diskRequests      prom.Counter
 	diskRequest       func()
+	cancelledRequests prom.Counter
+	cancelledRequest  func()
+	timeoutRequests   prom.Counter
+	timeoutRequest    func()
 	diskWaitDurations prom.Histogram
 	diskWaitDuration  func(time.Duration)
 
@@ -338,6 +342,14 @@ func (c *CarbonserverListener) InitPrometheus(reg prom.Registerer) {
 		diskRequests: prom.NewCounter(prom.CounterOpts{
 			Name: "disk_requests_total",
 			Help: "Number of times disk has been hit",
+		}),
+		cancelledRequests: prom.NewCounter(prom.CounterOpts{
+			Name: "cancelled_requests_total",
+			Help: "Number of times a request has been cancelled",
+		}),
+		timeoutRequests: prom.NewCounter(prom.CounterOpts{
+			Name: "timeout_requests_total",
+			Help: "Number of times a request has been timeout",
 		}),
 		diskWaitDurations: prom.NewHistogram(
 			prom.HistogramOpts{
@@ -391,6 +403,8 @@ func (c *CarbonserverListener) InitPrometheus(reg prom.Registerer) {
 
 	reg.MustRegister(c.prometheus.requests)
 	reg.MustRegister(c.prometheus.cacheRequests)
+	reg.MustRegister(c.prometheus.cancelledRequests)
+	reg.MustRegister(c.prometheus.timeoutRequests)
 	reg.MustRegister(c.prometheus.durations)
 	reg.MustRegister(c.prometheus.diskRequests)
 	reg.MustRegister(c.prometheus.diskWaitDurations)
@@ -436,6 +450,8 @@ func NewCarbonserverListener(cacheGetFunc func(key string) []points.Point) *Carb
 			cacheRequest:     func(string, bool) {},
 			cacheDuration:    func(string, time.Duration) {},
 			diskRequest:      func() {},
+			cancelledRequest: func() {},
+			timeoutRequest:   func() {},
 			diskWaitDuration: func(time.Duration) {},
 			returnedMetric:   func() {},
 			returnedPoint:    func(int) {},

--- a/carbonserver/find.go
+++ b/carbonserver/find.go
@@ -351,7 +351,6 @@ GATHER:
 			}
 
 		case <-ctx.Done():
-			done <- struct{}{}
 			return nil, fmt.Errorf("find failed, timeout")
 		}
 	}

--- a/carbonserver/find.go
+++ b/carbonserver/find.go
@@ -328,10 +328,9 @@ func (listener *CarbonserverListener) getExpandedGlobs(ctx context.Context, logg
 	var errors []findError
 	var err error
 	expGlobResultChan := make(chan *ExpandedGlobResponse, len(names))
-	done := make(chan struct{})
 
 	for _, name := range names {
-		go listener.expandGlobs(name, expGlobResultChan, done)
+		go listener.expandGlobs(name, expGlobResultChan)
 	}
 	responseCount := 0
 GATHER:

--- a/carbonserver/render.go
+++ b/carbonserver/render.go
@@ -335,8 +335,10 @@ func (listener *CarbonserverListener) prepareDataProto(ctx context.Context, logg
 		}
 	}
 	metricNames := make([]string, len(metricMap))
+	i := 0
 	for k := range metricMap {
-		metricNames = append(metricNames, k)
+		metricNames[i] = k
+		i++
 	}
 	expandedGlobs, err := listener.getExpandedGlobs(ctx, logger, time.Now(), metricNames)
 
@@ -346,7 +348,7 @@ func (listener *CarbonserverListener) prepareDataProto(ctx context.Context, logg
 
 	metricGlobMap := make(map[string]globs)
 	for _, expandedGlob := range expandedGlobs {
-		metricGlobMap[expandedGlob.Name] = expandedGlob
+		metricGlobMap[strings.Replace(expandedGlob.Name, "/", ".", -1)] = expandedGlob
 	}
 
 	var metrics []string

--- a/carbonserver/render.go
+++ b/carbonserver/render.go
@@ -2,6 +2,7 @@ package carbonserver
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -203,7 +204,7 @@ func (listener *CarbonserverListener) renderHandler(wr http.ResponseWriter, req 
 		}
 	}()
 
-	response, fromCache, err := listener.fetchWithCache(logger, format, targets)
+	response, fromCache, err := listener.fetchWithCache(ctx, logger, format, targets)
 
 	wr.Header().Set("Content-Type", response.contentType)
 	if err != nil {
@@ -249,7 +250,7 @@ func (listener *CarbonserverListener) renderHandler(wr http.ResponseWriter, req 
 
 }
 
-func (listener *CarbonserverListener) fetchWithCache(logger *zap.Logger, format responseFormat, targets map[timeRange][]target) (fetchResponse, bool, error) {
+func (listener *CarbonserverListener) fetchWithCache(ctx context.Context, logger *zap.Logger, format responseFormat, targets map[timeRange][]target) (fetchResponse, bool, error) {
 	logger = logger.With(
 		zap.String("function", "fetchWithCache"),
 	)
@@ -297,7 +298,7 @@ func (listener *CarbonserverListener) fetchWithCache(logger *zap.Logger, format 
 			logger.Debug("query cache miss")
 			atomic.AddUint64(&listener.metrics.QueryCacheMiss, 1)
 
-			response, err = listener.prepareDataProto(format, targets)
+			response, err = listener.prepareDataProto(ctx, logger, format, targets)
 			if err != nil {
 				item.StoreAbort()
 			} else {
@@ -311,21 +312,42 @@ func (listener *CarbonserverListener) fetchWithCache(logger *zap.Logger, format 
 			fromCache = true
 		}
 	} else {
-		response, err = listener.prepareDataProto(format, targets)
+		response, err = listener.prepareDataProto(ctx, logger, format, targets)
 	}
 	return response, fromCache, err
 }
 
-func (listener *CarbonserverListener) prepareDataProto(format responseFormat, targets map[timeRange][]target) (fetchResponse, error) {
+func (listener *CarbonserverListener) prepareDataProto(ctx context.Context, logger *zap.Logger, format responseFormat, targets map[timeRange][]target) (fetchResponse, error) {
 	contentType := "application/text"
 	var b []byte
-	var err error
 	var metricsFetched int
 	var memoryUsed int
 	var valuesFetched int
 
 	var multiv3 protov3.MultiFetchResponse
 	var multiv2 protov2.MultiFetchResponse
+
+	metricMap := make(map[string]bool)
+
+	for _, ts := range targets {
+		for _, metric := range ts {
+			metricMap[metric.Name] = true
+		}
+	}
+	metricNames := make([]string, len(metricMap))
+	for k := range metricMap {
+		metricNames = append(metricNames, k)
+	}
+	expandedGlobs, err := listener.getExpandedGlobs(ctx, logger, time.Now(), metricNames)
+
+	if expandedGlobs == nil {
+		return fetchResponse{nil, contentType, 0, 0, 0, nil}, err
+	}
+
+	metricGlobMap := make(map[string]globs)
+	for _, expandedGlob := range expandedGlobs {
+		metricGlobMap[expandedGlob.Name] = expandedGlob
+	}
 
 	var metrics []string
 	for tr, ts := range targets {
@@ -334,53 +356,56 @@ func (listener *CarbonserverListener) prepareDataProto(format responseFormat, ta
 			untilTime := tr.until
 
 			listener.logger.Debug("fetching data...")
-			files, leafs, err := listener.expandGlobs(metric.Name)
-			if err != nil {
+
+			if expandedResult, ok := metricGlobMap[metric.Name]; ok {
+				files, leafs := expandedResult.Files, expandedResult.Leafs
+
+				metricsCount := 0
+				for i := range files {
+					if leafs[i] {
+						metricsCount++
+					}
+				}
+				listener.logger.Debug("expandGlobs result",
+					zap.String("handler", "render"),
+					zap.String("action", "expandGlobs"),
+					zap.String("metric", metric.Name),
+					zap.Int("metrics_count", metricsCount),
+					zap.Int32("from", fromTime),
+					zap.Int32("until", untilTime),
+				)
+
+				if format == protoV2Format || format == jsonFormat {
+					res, err := listener.fetchDataPB(metric.Name, files, leafs, fromTime, untilTime)
+					if err != nil {
+						atomic.AddUint64(&listener.metrics.RenderErrors, 1)
+						listener.logger.Error("error while fetching the data",
+							zap.Error(err),
+						)
+						continue
+					}
+					multiv2.Metrics = append(multiv2.Metrics, res.Metrics...)
+				} else {
+					res, err := listener.fetchDataPB3(metric.Name, files, leafs, fromTime, untilTime)
+					if err != nil {
+						atomic.AddUint64(&listener.metrics.RenderErrors, 1)
+						listener.logger.Error("error while fetching the data",
+							zap.Error(err),
+						)
+						continue
+					}
+					for i := range res.Metrics {
+						res.Metrics[i].PathExpression = metric.PathExpression
+					}
+					multiv3.Metrics = append(multiv3.Metrics, res.Metrics...)
+				}
+			} else {
 				listener.logger.Debug("expand globs returned an error",
 					zap.Error(err),
 				)
 				continue
 			}
 
-			metricsCount := 0
-			for i := range files {
-				if leafs[i] {
-					metricsCount++
-				}
-			}
-			listener.logger.Debug("expandGlobs result",
-				zap.String("handler", "render"),
-				zap.String("action", "expandGlobs"),
-				zap.String("metric", metric.Name),
-				zap.Int("metrics_count", metricsCount),
-				zap.Int32("from", fromTime),
-				zap.Int32("until", untilTime),
-			)
-
-			if format == protoV2Format || format == jsonFormat {
-				res, err := listener.fetchDataPB(metric.Name, files, leafs, fromTime, untilTime)
-				if err != nil {
-					atomic.AddUint64(&listener.metrics.RenderErrors, 1)
-					listener.logger.Error("error while fetching the data",
-						zap.Error(err),
-					)
-					continue
-				}
-				multiv2.Metrics = append(multiv2.Metrics, res.Metrics...)
-			} else {
-				res, err := listener.fetchDataPB3(metric.Name, files, leafs, fromTime, untilTime)
-				if err != nil {
-					atomic.AddUint64(&listener.metrics.RenderErrors, 1)
-					listener.logger.Error("error while fetching the data",
-						zap.Error(err),
-					)
-					continue
-				}
-				for i := range res.Metrics {
-					res.Metrics[i].PathExpression = metric.PathExpression
-				}
-				multiv3.Metrics = append(multiv3.Metrics, res.Metrics...)
-			}
 		}
 	}
 


### PR DESCRIPTION
This pull request aims to introduce context cancellations to go-carbon. Currently, cancellations are implemented in api and zipper but not in go-carbon. This will help avoid uneeded work(in case client is gone), or when the request is taking too much time, and reduce load on the server.