### PR TITLE
Added Prometheus metric to count number of incoming datapoints in TCP receiver.

### DIFF
--- a/carbon/app.go
+++ b/carbon/app.go
@@ -369,6 +369,10 @@ func (app *App) Start() (err error) {
 			return
 		}
 
+		if conf.Prometheus.Enabled {
+			rcv.InitPrometheus(app.PromRegisterer)
+		}
+
 		app.Receivers = append(app.Receivers, &NamedReceiver{
 			Receiver: rcv,
 			Name:     "tcp",

--- a/receiver/http/http.go
+++ b/receiver/http/http.go
@@ -15,6 +15,7 @@ import (
 	"github.com/lomik/go-carbon/receiver"
 	"github.com/lomik/go-carbon/receiver/parse"
 	"github.com/lomik/zapwriter"
+	"github.com/prometheus/client_golang/prometheus"
 )
 
 func init() {
@@ -159,4 +160,8 @@ func (rcv *HTTP) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	atomic.AddUint32(&rcv.metricsReceived, uint32(cnt))
+}
+
+// InitPrometheus is a stub for the receiver prom metrics. Required to satisfy Receiver interface.
+func (rcv *HTTP) InitPrometheus(reg prometheus.Registerer) {
 }

--- a/receiver/kafka/kafka.go
+++ b/receiver/kafka/kafka.go
@@ -20,6 +20,7 @@ import (
 	"github.com/lomik/go-carbon/receiver"
 	"github.com/lomik/go-carbon/receiver/parse"
 	"github.com/lomik/zapwriter"
+	"github.com/prometheus/client_golang/prometheus"
 )
 
 func init() {
@@ -498,4 +499,8 @@ func (rcv *Kafka) worker() {
 			rcv.Unlock()
 		}
 	}
+}
+
+// InitPrometheus is a stub for the receiver prom metrics. Required to satisfy Receiver interface.
+func (rcv *Kafka) InitPrometheus(reg prometheus.Registerer) {
 }

--- a/receiver/pubsub/pubsub.go
+++ b/receiver/pubsub/pubsub.go
@@ -19,6 +19,7 @@ import (
 	"github.com/lomik/go-carbon/receiver"
 	"github.com/lomik/go-carbon/receiver/parse"
 	"github.com/lomik/zapwriter"
+	"github.com/prometheus/client_golang/prometheus"
 )
 
 // gzipPool provides a sync.Pool of initialized gzip.Readers's to avoid
@@ -245,4 +246,8 @@ func acquireGzipReader(r io.Reader) (*gzip.Reader, error) {
 func releaseGzipReader(zr *gzip.Reader) {
 	zr.Close()
 	gzipPool.Put(zr)
+}
+
+// InitPrometheus is a stub for the receiver prom metrics. Required to satisfy Receiver interface.
+func (rcv *PubSub) InitPrometheus(reg prometheus.Registerer) {
 }

--- a/receiver/receiver.go
+++ b/receiver/receiver.go
@@ -9,11 +9,13 @@ import (
 	"github.com/BurntSushi/toml"
 	"github.com/lomik/go-carbon/helper"
 	"github.com/lomik/go-carbon/points"
+	"github.com/prometheus/client_golang/prometheus"
 )
 
 type Receiver interface {
 	Stop()
 	Stat(helper.StatCallback)
+	InitPrometheus(prometheus.Registerer)
 }
 
 type protocolRecord struct {

--- a/receiver/tcp/tcp.go
+++ b/receiver/tcp/tcp.go
@@ -87,7 +87,7 @@ type TCP struct {
 	name                string // name for store metrics
 	maxMessageSize      uint32
 	metricsReceived     uint32
-	promMetricsReceived prometheus.Gauge
+	promMetricsReceived prometheus.Counter
 	errors              uint32
 	active              int32 // counter
 	listener            *net.TCPListener
@@ -307,7 +307,7 @@ func (rcv *TCP) Stat(send helper.StatCallback) {
 	atomic.AddUint32(&rcv.metricsReceived, -metricsReceived)
 	send("metricsReceived", float64(metricsReceived))
 	if rcv.promMetricsReceived != nil {
-		rcv.promMetricsReceived.Set(float64(metricsReceived))
+		rcv.promMetricsReceived.Add(float64(metricsReceived))
 	}
 
 	active := float64(atomic.LoadInt32(&rcv.active))
@@ -410,10 +410,10 @@ func newDecompressor(typ string) decompressor {
 }
 
 func (rcv *TCP) InitPrometheus(reg prometheus.Registerer) {
-	rcv.promMetricsReceived = prometheus.NewGauge(
-		prometheus.GaugeOpts{
-			Name: "metrics_received_tcp",
-			Help: "How many metrics were received by the TCP endpoint.",
+	rcv.promMetricsReceived = prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Name: "metrics_received_tcp_total",
+			Help: "Counter of metrics received via the TCP endpoint.",
 		},
 	)
 

--- a/receiver/tcp/tcp.go
+++ b/receiver/tcp/tcp.go
@@ -20,6 +20,7 @@ import (
 	"github.com/lomik/go-carbon/receiver/parse"
 	"github.com/lomik/graphite-pickle/framing"
 	"github.com/lomik/zapwriter"
+	"github.com/prometheus/client_golang/prometheus"
 )
 
 func init() {
@@ -82,18 +83,19 @@ func NewFramingOptions() *FramingOptions {
 // TCP receive metrics from TCP connections
 type TCP struct {
 	helper.Stoppable
-	out             func(*points.Points)
-	name            string // name for store metrics
-	maxMessageSize  uint32
-	metricsReceived uint32
-	errors          uint32
-	active          int32 // counter
-	listener        *net.TCPListener
-	isFraming       bool
-	frameParser     func(body []byte) ([]*points.Points, error)
-	buffer          chan *points.Points
-	logger          *zap.Logger
-	decompressor    decompressor
+	out                 func(*points.Points)
+	name                string // name for store metrics
+	maxMessageSize      uint32
+	metricsReceived     uint32
+	promMetricsReceived prometheus.Gauge
+	errors              uint32
+	active              int32 // counter
+	listener            *net.TCPListener
+	isFraming           bool
+	frameParser         func(body []byte) ([]*points.Points, error)
+	buffer              chan *points.Points
+	logger              *zap.Logger
+	decompressor        decompressor
 }
 
 // Addr returns binded socket address. For bind port 0 in tests
@@ -304,6 +306,9 @@ func (rcv *TCP) Stat(send helper.StatCallback) {
 	metricsReceived := atomic.LoadUint32(&rcv.metricsReceived)
 	atomic.AddUint32(&rcv.metricsReceived, -metricsReceived)
 	send("metricsReceived", float64(metricsReceived))
+	if rcv.promMetricsReceived != nil {
+		rcv.promMetricsReceived.Set(float64(metricsReceived))
+	}
 
 	active := float64(atomic.LoadInt32(&rcv.active))
 	send("active", active)
@@ -402,4 +407,15 @@ func newDecompressor(typ string) decompressor {
 			return c, nil
 		}
 	}
+}
+
+func (rcv *TCP) InitPrometheus(reg prometheus.Registerer) {
+	rcv.promMetricsReceived = prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Name: "metrics_received_tcp",
+			Help: "How many metrics were received by the TCP endpoint.",
+		},
+	)
+
+	reg.MustRegister(rcv.promMetricsReceived)
 }

--- a/receiver/udp/udp.go
+++ b/receiver/udp/udp.go
@@ -13,6 +13,7 @@ import (
 	"github.com/lomik/go-carbon/receiver"
 	"github.com/lomik/go-carbon/receiver/parse"
 	"github.com/lomik/zapwriter"
+	"github.com/prometheus/client_golang/prometheus"
 )
 
 func init() {
@@ -184,4 +185,8 @@ func (rcv *UDP) Listen(addr *net.UDPAddr) error {
 
 		return nil
 	})
+}
+
+// InitPrometheus is a stub for the receiver prom metrics. Required to satisfy Receiver interface.
+func (rcv *UDP) InitPrometheus(reg prometheus.Registerer) {
 }


### PR DESCRIPTION
This metric is quite useful in following cases:

- checking if storages receive expected number datapoints, e.g. if there is no significant data loss
- to monitor the incoming traffic for load estimation and fluctuations

Currently, the implementation is only for TCP. Can be added for other protocols as well.