### PR TITLE
bugfix: unconfirmed metrics 

### DIFF
--- a/carbon/app.go
+++ b/carbon/app.go
@@ -272,6 +272,7 @@ func (app *App) startPersister() {
 			app.Cache.WriteoutQueue().Get,
 			app.Cache.PopNotConfirmed,
 			app.Cache.Confirm,
+			app.Cache.Pop,
 		)
 		p.SetMaxUpdatesPerSecond(app.Config.Whisper.MaxUpdatesPerSecond)
 		p.SetMaxCreatesPerSecond(app.Config.Whisper.MaxCreatesPerSecond)

--- a/persister/whisper_stop_test.go
+++ b/persister/whisper_stop_test.go
@@ -49,7 +49,7 @@ func TestGracefullyStop(t *testing.T) {
 
 		qa.Root(t, func(root string) {
 			recv, pop := makeRecvPopFromChan(ch)
-			p := NewWhisper(root, nil, nil, recv, pop, nil)
+			p := NewWhisper(root, nil, nil, recv, pop, nil, nil)
 			p.SetMaxUpdatesPerSecond(maxUpdatesPerSecond)
 			p.SetWorkers(workers)
 
@@ -112,7 +112,7 @@ func TestStopEmptyThrottledPersister(t *testing.T) {
 
 				ch := make(chan *points.Points, 10)
 				recv, pop := makeRecvPopFromChan(ch)
-				p := NewWhisper(root, nil, nil, recv, pop, nil)
+				p := NewWhisper(root, nil, nil, recv, pop, nil, nil)
 				p.SetMaxUpdatesPerSecond(maxUpdatesPerSecond)
 				p.SetWorkers(workers)
 


### PR DESCRIPTION
In three cases we would pop metrics without confirming them:

a) when failing to create new files(for example filename is too long)
b) when failing to remove empty file
c) when throttling creates using 'hard' mode

In this case metrics would stay forever in the 'notConfirmed' array. If 'dump' option is enabled, they would even be persisted between restarts. 

Depending on configuration options used, this can lead to various issues:
 - performance degradation over time as size of nonConfirmed array grows. That should make each Get() slower.
 - metrics from point c) coming back after restarts if we have dump option enabled.
 - with dump option enabled, we would never get rid of those metrics 

The way I reproduced this issue is like this:
a) generate very long metric name. Close go-carbon with USR2 & save the cache. We can see the metric in the cache dump.
b) did not try to reproduce this case. As we are returning after pop(), I thought this can cause same problem
c) use configuration with 
```
max-creates-per-second = 1
hard-max-creates-per-second = true
```
Send 10k random metrics. Close go-carbon with USR2 & save cache. We can see metrics in cache dump.
At this point, if we start again go-carbon with `max-creates-per-second=0`  we can see all  new files being created.

Example output from the script that I used to reproduce this issue:

For case a)
```
Generating input with very long filename
Starting go-carbon
GO_CARBON_PID: 576606. Waiting for go-carbon to start
Sending metrics to go-carbon
Sleeping for a while
Stopping go-carbon
Inspecting dump files
Dump files: cache.576606.1573419306296798904.bin
input.576606.1573419306296798904
Files so far: 0 # we failed to create any file, as metric name was too long
Points in cache dump: 1 dump_files # we still have the very long metric name in cache dump
```

For case c)
```
Generating input with 1000 metrics
Starting go-carbon
GO_CARBON_PID: 576542. Waiting for go-carbon to start
Sending metrics to go-carbon
Sleeping for a while
Stopping go-carbon
Inspecting dump files
Dump files: cache.576542.1573419228865477694.bin
input.576542.1573419228865477694
Files so far: 2 # we created two files
Points in cache dump: 998 dump_files # we still have 998 metrics in cache dump.
```
I'm attaching script to reproduce issue and configuration files that I used:

[run.sh.txt](https://github.com/lomik/go-carbon/files/3829022/run.sh.txt)
[c1.ini.txt](https://github.com/lomik/go-carbon/files/3829023/c1.ini.txt)
[c2.ini.txt](https://github.com/lomik/go-carbon/files/3829024/c2.ini.txt) -> this one is just like c1 just without rate limiting for creates.
