### PR TITLE
A concurrent version of trie index

### DIFF
--- a/README.md
+++ b/README.md
@@ -327,6 +327,17 @@ scan-frequency = "5m0s"
 #  memory usage (by setting both trie-index and trigram-index to true).
 trie-index = false
 
+# Enable concurrently building index without maintaining a new copy
+# index structure. More memory efficient.
+# Currently only trie-index is supported. (EXPERIMENTAL)
+concurrent-idnex = false
+
+# Set to larger than 0 to enable realtime indexing of new metrics,
+# The value controls how many new metrics could be buffered at once. Suitable to
+# adjust it higher if there are high number of new metrics being produced.
+# Currently only trie-index is supported. (EXPERIMENTAL)
+realtime-index = 0
+
 # This provides the ability to query for new metrics without any wsp files
 # i.e query for metrics present only in cache. Does a cache-scan and
 # populates index with metrics with or without corresponding wsp files,

--- a/README.md
+++ b/README.md
@@ -327,6 +327,14 @@ scan-frequency = "5m0s"
 #  memory usage (by setting both trie-index and trigram-index to true).
 trie-index = false
 
+# Cache file list scan data in the specified path. This option speeds
+# up index building after reboot by reading the last scan result in file
+# system instead of scanning the whole data dir, which could takes up
+# most of the indexing time if it contains a high number of metrics (10
+# - 40 millions). go-carbon only reads the cached file list once after
+# reboot and the cache result is updated after every scan.
+file-list-cache = ""
+
 # Enable concurrently building index without maintaining a new copy
 # index structure. More memory efficient.
 # Currently only trie-index is supported. (EXPERIMENTAL)

--- a/README.md
+++ b/README.md
@@ -332,13 +332,13 @@ trie-index = false
 # system instead of scanning the whole data dir, which could takes up
 # most of the indexing time if it contains a high number of metrics (10
 # - 40 millions). go-carbon only reads the cached file list once after
-# reboot and the cache result is updated after every scan.
+# reboot and the cache result is updated after every scan. (EXPERIMENTAL)
 file-list-cache = ""
 
 # Enable concurrently building index without maintaining a new copy
 # index structure. More memory efficient.
 # Currently only trie-index is supported. (EXPERIMENTAL)
-concurrent-idnex = false
+concurrent-index = false
 
 # Set to larger than 0 to enable realtime indexing of new metrics,
 # The value controls how many new metrics could be buffered at once. Suitable to

--- a/carbon/app.go
+++ b/carbon/app.go
@@ -457,6 +457,8 @@ func (app *App) Start(version string) (err error) {
 		carbonserver.SetQueryCacheSizeMB(conf.Carbonserver.QueryCacheSizeMB)
 		carbonserver.SetTrigramIndex(conf.Carbonserver.TrigramIndex)
 		carbonserver.SetTrieIndex(conf.Carbonserver.TrieIndex)
+		carbonserver.SetConcurrentIndex(conf.Carbonserver.ConcurrentIndex)
+		carbonserver.SetFileListCache(conf.Carbonserver.FileListCache)
 		carbonserver.SetInternalStatsDir(conf.Carbonserver.InternalStatsDir)
 		carbonserver.SetPercentiles(conf.Carbonserver.Percentiles)
 		// carbonserver.SetQueryTimeout(conf.Carbonserver.QueryTimeout.Value())

--- a/carbon/app.go
+++ b/carbon/app.go
@@ -473,6 +473,11 @@ func (app *App) Start(version string) (err error) {
 			carbonserver.SetConfigRetriever(retriever)
 		}
 
+		if conf.Carbonserver.RealtimeIndex > 0 {
+			ch := carbonserver.SetRealtimeIndex(conf.Carbonserver.RealtimeIndex)
+			core.SetNewMetricsChan(ch)
+		}
+
 		if conf.Prometheus.Enabled {
 			carbonserver.InitPrometheus(app.PromRegisterer)
 		}

--- a/carbon/config.go
+++ b/carbon/config.go
@@ -117,7 +117,9 @@ type carbonserverConfig struct {
 	MaxMetricsGlobbed  int `toml:"max-metrics-globbed"`
 	MaxMetricsRendered int `toml:"max-metrics-rendered"`
 
-	TrieIndex bool `toml:"trie-index"`
+	TrieIndex       bool   `toml:"trie-index"`
+	ConcurrentIndex bool   `toml:"concurrent-index"`
+	FileListCache   string `toml:"flie-list-cache"`
 }
 
 type pprofConfig struct {

--- a/carbon/config.go
+++ b/carbon/config.go
@@ -119,7 +119,7 @@ type carbonserverConfig struct {
 
 	TrieIndex       bool   `toml:"trie-index"`
 	ConcurrentIndex bool   `toml:"concurrent-index"`
-	FileListCache   string `toml:"flie-list-cache"`
+	FileListCache   string `toml:"file-list-cache"`
 }
 
 type pprofConfig struct {

--- a/carbon/config.go
+++ b/carbon/config.go
@@ -119,6 +119,7 @@ type carbonserverConfig struct {
 
 	TrieIndex       bool   `toml:"trie-index"`
 	ConcurrentIndex bool   `toml:"concurrent-index"`
+	RealtimeIndex   int    `toml:"realtime-index"`
 	FileListCache   string `toml:"file-list-cache"`
 }
 

--- a/carbonserver/carbonserver.go
+++ b/carbonserver/carbonserver.go
@@ -619,12 +619,17 @@ func (listener *CarbonserverListener) updateFileList(dir string, cacheMetricName
 		}
 	}()
 
+	fidx := listener.CurrentFileIndex()
+
 	var files []string
 	var filesLen int
 	details := make(map[string]*protov3.MetricDetails)
 	var trieIdx *trieIndex
-	if listener.trieIndex {
+	if listener.trieIndex && fidx == nil {
 		trieIdx = newTrie(".wsp")
+	} else {
+		trieIdx = fidx.trieIdx
+		trieIdx.root.mark++
 	}
 
 	metricsKnown := uint64(0)
@@ -748,7 +753,6 @@ func (listener *CarbonserverListener) updateFileList(dir string, cacheMetricName
 	atomic.AddUint64(&listener.metrics.IndexBuildTimeNS, uint64(indexingRuntime.Nanoseconds()))
 
 	tl := time.Now()
-	fidx := listener.CurrentFileIndex()
 
 	if fidx != nil && listener.internalStatsDir != "" {
 		listener.fileIdxMutex.Lock()

--- a/carbonserver/carbonserver.go
+++ b/carbonserver/carbonserver.go
@@ -17,8 +17,11 @@
 package carbonserver
 
 import (
+	"bufio"
+	"compress/gzip"
 	"context"
 	"encoding/binary"
+	"errors"
 	"fmt"
 	"math"
 	"net"
@@ -224,6 +227,8 @@ type CarbonserverListener struct {
 	findCache         queryCache
 	trigramIndex      bool
 	trieIndex         bool
+	concurrentIndex   bool
+	fileListCache     string
 
 	fileIdx      atomic.Value
 	fileIdxMutex sync.Mutex
@@ -503,6 +508,12 @@ func (listener *CarbonserverListener) SetCacheGetMetricsFunc(recentMetricsFunc f
 func (listener *CarbonserverListener) SetConfigRetriever(retriever configRetriever) {
 	listener.whisperGetConfig = retriever
 }
+func (listener *CarbonserverListener) SetConcurrentIndex(enabled bool) {
+	listener.concurrentIndex = enabled
+}
+func (listener *CarbonserverListener) SetFileListCache(path string) {
+	listener.fileListCache = path
+}
 func (listener *CarbonserverListener) SetInternalStatsDir(dbPath string) {
 	listener.internalStatsDir = dbPath
 }
@@ -619,20 +630,21 @@ func (listener *CarbonserverListener) updateFileList(dir string, cacheMetricName
 		}
 	}()
 
-	fidx := listener.CurrentFileIndex()
-
+	var t0 = time.Now()
+	var fidx = listener.CurrentFileIndex()
 	var files []string
 	var filesLen int
-	details := make(map[string]*protov3.MetricDetails)
+	var details = make(map[string]*protov3.MetricDetails)
 	var trieIdx *trieIndex
-	if listener.trieIndex && fidx == nil {
-		trieIdx = newTrie(".wsp")
-	} else {
-		trieIdx = fidx.trieIdx
-		trieIdx.root.mark++
+	var metricsKnown uint64
+	if listener.trieIndex {
+		if fidx == nil || !listener.concurrentIndex {
+			trieIdx = newTrie(".wsp")
+		} else {
+			trieIdx = fidx.trieIdx
+			trieIdx.root.mark++
+		}
 	}
-
-	metricsKnown := uint64(0)
 
 	// populate index for all the metric names in cache
 	// the iteration takes place only when cache-scan is enabled in conf
@@ -650,20 +662,86 @@ func (listener *CarbonserverListener) updateFileList(dir string, cacheMetricName
 		}
 	}
 
-	t0 := time.Now()
-	err := filepath.Walk(dir, func(p string, info os.FileInfo, err error) error {
+	var readFromCache bool
+	if fidx == nil && listener.fileListCache != "" {
+		fileListCache, err := newFileListCache(listener.fileListCache, 'r')
 		if err != nil {
-			logger.Info("error processing", zap.String("path", p), zap.Error(err))
-			return nil
+			if !os.IsNotExist(err) {
+				logger.Error("failed to read file list cache", zap.Error(err))
+			}
+		} else {
+			readFromCache = true
+			for fileListCache.scanner.Scan() {
+				entry := fileListCache.scanner.Text()
+				if entry == "" {
+					continue
+				}
+				if err := trieIdx.insert(entry); err != nil {
+					logger.Error("failed to read from file list cache", zap.Error(err))
+					readFromCache = false
+					break
+				}
+				filesLen++
+				if strings.HasSuffix(entry, ".wsp") {
+					metricsKnown++
+				}
+			}
+			if err := fileListCache.close(); err != nil {
+				logger.Error("failed to close file list cache", zap.Error(err))
+			}
 		}
+	}
 
-		hasSuffix := strings.HasSuffix(info.Name(), ".wsp")
-		if info.IsDir() || hasSuffix {
-			trimmedName := strings.TrimPrefix(p, listener.whisperData)
-			filesLen++
-			// use cacheMetricNames to check and prevent appending duplicate metrics
-			// into the index when cacheMetricNamesIndex is enabled
-			if _, present := cacheMetricNames[trimmedName]; !present {
+	if !readFromCache {
+		var flc *fileListCache
+		if listener.fileListCache != "" {
+			var err error
+			flc, err = newFileListCache(listener.fileListCache, 'w')
+			if err != nil {
+				if !os.IsNotExist(err) {
+					logger.Error("failed to create file list cache", zap.Error(err))
+				}
+			} else {
+				defer func() {
+					if err := flc.close(); err != nil {
+						logger.Error("failed to close flie list cache", zap.Error(err))
+					}
+				}()
+			}
+		}
+		err := filepath.Walk(dir, func(p string, info os.FileInfo, err error) error {
+			if err != nil {
+				logger.Info("error processing", zap.String("path", p), zap.Error(err))
+				return nil
+			}
+
+			hasSuffix := strings.HasSuffix(info.Name(), ".wsp")
+			if info.IsDir() || hasSuffix {
+				trimmedName := strings.TrimPrefix(p, listener.whisperData)
+				filesLen++
+				// use cacheMetricNames to check and prevent appending duplicate metrics
+				// into the index when cacheMetricNamesIndex is enabled
+				if _, present := cacheMetricNames[trimmedName]; !present {
+					if listener.trieIndex {
+						if err := trieIdx.insert(trimmedName); err != nil {
+							return fmt.Errorf("updateFileList.trie: %s", err)
+						}
+					} else {
+						files = append(files, trimmedName)
+					}
+					if hasSuffix {
+						metricsKnown++
+					}
+				}
+
+				if flc != nil {
+					if err := flc.write(trimmedName); err != nil {
+						logger.Error("failed to write to file list cache", zap.Error(err))
+						flc.file.Close()
+						flc = nil
+					}
+				}
+
 				if listener.trieIndex {
 					if err := trieIdx.insert(trimmedName); err != nil {
 						return fmt.Errorf("updateFileList.trie: %s", err)
@@ -671,36 +749,37 @@ func (listener *CarbonserverListener) updateFileList(dir string, cacheMetricName
 				} else {
 					files = append(files, trimmedName)
 				}
+
 				if hasSuffix {
 					metricsKnown++
-				}
-			}
-
-			if hasSuffix {
-				if listener.internalStatsDir != "" {
-					i := stat.GetStat(info)
-					trimmedName = strings.Replace(trimmedName[1:len(trimmedName)-4], "/", ".", -1)
-					details[trimmedName] = &protov3.MetricDetails{
-						Size_:    i.Size,
-						ModTime:  i.MTime,
-						ATime:    i.ATime,
-						RealSize: i.RealSize,
+					if listener.internalStatsDir != "" {
+						i := stat.GetStat(info)
+						trimmedName = strings.Replace(trimmedName[1:len(trimmedName)-4], "/", ".", -1)
+						details[trimmedName] = &protov3.MetricDetails{
+							Size_:    i.Size,
+							ModTime:  i.MTime,
+							ATime:    i.ATime,
+							RealSize: i.RealSize,
+						}
 					}
 				}
 			}
-		}
 
-		return nil
-	})
-	if err != nil {
-		logger.Error("error getting file list",
-			zap.Error(err),
-		)
+			return nil
+		})
+		if err != nil {
+			logger.Error("error getting file list",
+				zap.Error(err),
+			)
+		}
+	}
+
+	if listener.concurrentIndex && fidx != nil {
+		trieIdx.prune()
 	}
 
 	var stat syscall.Statfs_t
-	err = syscall.Statfs(dir, &stat)
-	if err != nil {
+	if err := syscall.Statfs(dir, &stat); err != nil {
 		logger.Info("error getting FS Stats",
 			zap.String("dir", dir),
 			zap.Error(err),
@@ -738,7 +817,7 @@ func (listener *CarbonserverListener) updateFileList(dir string, cacheMetricName
 			zap.Int("trie_depth", nfidx.trieIdx.depth),
 			zap.String("longest_metric", nfidx.trieIdx.longestMetric),
 		)
-		if listener.trigramIndex {
+		if listener.trigramIndex && !listener.concurrentIndex {
 			start := time.Now()
 			nfidx.trieIdx.setTrigrams()
 			infos = append(infos, zap.Duration("set_trigram_time", time.Now().Sub(start))) //nolint:gosimple
@@ -752,8 +831,7 @@ func (listener *CarbonserverListener) updateFileList(dir string, cacheMetricName
 	indexingRuntime := time.Since(t0)
 	atomic.AddUint64(&listener.metrics.IndexBuildTimeNS, uint64(indexingRuntime.Nanoseconds()))
 
-	tl := time.Now()
-
+	var tl = time.Now()
 	if fidx != nil && listener.internalStatsDir != "" {
 		listener.fileIdxMutex.Lock()
 		for m := range fidx.accessTimes {
@@ -769,7 +847,7 @@ func (listener *CarbonserverListener) updateFileList(dir string, cacheMetricName
 		nfidx.accessTimes = fidx.accessTimes
 		listener.fileIdxMutex.Unlock()
 	}
-	rdTimeUpdateRuntime := time.Since(tl)
+	var rdTimeUpdateRuntime = time.Since(tl)
 
 	listener.UpdateFileIndex(nfidx)
 
@@ -782,6 +860,7 @@ func (listener *CarbonserverListener) updateFileList(dir string, cacheMetricName
 		zap.Int("index_size", indexSize),
 		zap.Int("pruned_trigrams", pruned),
 		zap.String("index_type", indexType),
+		zap.Bool("read_from_cache", readFromCache),
 	)
 	logger.Info("file list updated", infos...)
 }
@@ -1323,4 +1402,73 @@ func extractTrigrams(query string) []trigram.T {
 	}
 
 	return trigrams
+}
+
+type fileListCache struct {
+	path    string
+	mode    byte
+	file    *os.File
+	scanner *bufio.Scanner
+	writer  *gzip.Writer
+}
+
+func newFileListCache(p string, mode byte) (*fileListCache, error) {
+	var flc fileListCache
+	var err error
+	flc.path = p
+	flc.mode = mode
+	if mode == 'r' {
+		flc.file, err = os.Open(p)
+		if err != nil {
+			return nil, err
+		}
+		r, err := gzip.NewReader(flc.file)
+		if err != nil {
+			return nil, err
+		}
+		flc.scanner = bufio.NewScanner(r)
+	}
+	if mode == 'w' {
+		flc.file, err = os.Create(p + ".tmp")
+		if err != nil {
+			return nil, err
+		}
+		flc.writer = gzip.NewWriter(flc.file)
+	}
+	return &flc, err
+}
+
+func (flc *fileListCache) write(p string) error {
+	_, err := flc.writer.Write([]byte(p + "\n"))
+	return err
+}
+
+func (flc *fileListCache) close() error {
+	var errs []string
+	if flc.mode == 'w' {
+		if err := flc.writer.Flush(); err != nil {
+			errs = append(errs, fmt.Sprintf("gzip.flush: %s", err))
+		}
+		if err := flc.writer.Close(); err != nil {
+			errs = append(errs, fmt.Sprintf("gzip.close: %s", err))
+		}
+		if err := flc.file.Sync(); err != nil {
+			errs = append(errs, fmt.Sprintf("file.sync: %s", err))
+		}
+	}
+	if err := flc.file.Close(); err != nil {
+		errs = append(errs, fmt.Sprintf("file.sync: %s", err))
+	}
+
+	if flc.mode == 'w' && len(errs) == 0 {
+		if err := os.Rename(flc.path+".tmp", flc.path); err != nil {
+			errs = append(errs, fmt.Sprintf("file.rename: %s", err))
+		}
+	}
+
+	if len(errs) > 0 {
+		return errors.New(strings.Join(errs, ";"))
+	}
+
+	return nil
 }

--- a/carbonserver/fetchsinglemetric.go
+++ b/carbonserver/fetchsinglemetric.go
@@ -132,7 +132,7 @@ func (listener *CarbonserverListener) fetchSingleMetric(metric string, pathExpre
 		)
 
 		return resp, nil
-	case os.IsNotExist(err) && listener.cacheGetRecentMetrics != nil:
+	case os.IsNotExist(err) && (listener.cacheGetRecentMetrics != nil || listener.realtimeIndex > 0):
 		//Failed to fetch from disk, try to fetch from cache
 		resp := response{
 			Name:           metric,

--- a/carbonserver/trie.go
+++ b/carbonserver/trie.go
@@ -1000,13 +1000,6 @@ func (ti *trieIndex) prune() {
 
 	for {
 		if cur.next >= len(cur.childrens) {
-			// for _, s := range states {
-			// 	if s.node != nil {
-			// 		fmt.Printf("%s", s.node.c)
-			// 	}
-			// }
-			// fmt.Println("")
-
 			cc := cur.node.getChildrens()
 			if idx > 0 && !cur.node.dir() && len(cc) == 1 && !cc[0].file() && !cc[0].dir() {
 				n := &trieNode{childrens: cc[0].childrens, gen: ti.root.gen}

--- a/carbonserver/trie.go
+++ b/carbonserver/trie.go
@@ -385,7 +385,7 @@ func (ti *trieIndex) insert(path string) error {
 		path = path[:len(path)-len(ti.fileExt)]
 	}
 
-	var start, match, nlen int
+	var start, nlen int
 	var sn, newn *trieNode
 outer:
 	for i := 0; i < len(path)+1; i++ {
@@ -422,7 +422,7 @@ outer:
 	inner:
 		for ci := 0; ci < len(*cur.childrens); ci++ {
 			child := (*cur.childrens)[ci]
-			match = 0
+			match := 0
 
 			if len(child.c) == 0 || child.c[0] != path[start] {
 				continue
@@ -1004,7 +1004,9 @@ func (ti *trieIndex) prune() {
 			cc := cur.node.getChildrens()
 			if idx > 0 && !cur.node.dir() && len(cc) == 1 && !cc[0].file() && !cc[0].dir() {
 				n := &trieNode{childrens: cc[0].childrens, gen: ti.root.gen}
-				n.c = append(cur.node.c, cc[0].c...)
+				n.c = make([]byte, 0, len(cur.node.c)+len(cc[0].c))
+				n.c = append(n.c, cur.node.c...)
+				n.c = append(n.c, cc[0].c...)
 				for i, t := range *states[idx-1].node.childrens {
 					if t == cur.node {
 						states[idx-1].node.setChild(i, n)

--- a/carbonserver/trie_real_test.go
+++ b/carbonserver/trie_real_test.go
@@ -67,7 +67,7 @@ func TestTrieGlobRealData(t *testing.T) {
 	var wg sync.WaitGroup
 	wg.Add(1)
 	go func() {
-		trieServer = newTrieServer(files, !*pureTrie)
+		trieServer = newTrieServer(files, !*pureTrie, t)
 		trieServer.whisperData = *carbonPath
 
 		if *checkMemory {
@@ -80,7 +80,7 @@ func TestTrieGlobRealData(t *testing.T) {
 	if !*noTrigram {
 		wg.Add(1)
 		go func() {
-			trigramServer = newTrigramServer(files)
+			trigramServer = newTrigramServer(files, t)
 			trigramServer.whisperData = *carbonPath
 
 			if *checkMemory {

--- a/carbonserver/trie_test.go
+++ b/carbonserver/trie_test.go
@@ -718,11 +718,16 @@ func TestTriePrune(t *testing.T) {
 
 	trieIndex.insert("/level-0/level-1/level-2/memory.wsp")
 	trieIndex.insert("/level-0/level-1/level-2-1/memory.wsp")
+	trieIndex.insert("/level-0/level-1/level-2-2.wsp")
+	trieIndex.insert("/level-0/level-1/level-2-2/memory1.wsp")
 	trieIndex.insert("/level-0/level-1/level-2-2/memory.wsp")
+	trieIndex.insert("/level-0/level-1/level-2-2/memory2.wsp")
 	trieIndex.insert("/level-0/level-1/cpu.wsp")
 	trieIndex.insert("/level-0/disk.wsp")
 
 	// trieIndex.dump(os.Stdout)
+
+	// println(trieIndex.countNodes())
 
 	trieIndex.root.mark++
 	trieIndex.insert("/level-0/level-1/cpu.wsp")
@@ -731,8 +736,13 @@ func TestTriePrune(t *testing.T) {
 
 	// trieIndex.dump(os.Stdout)
 
+	// println(trieIndex.countNodes())
+
 	trieIndex.prune()
 	// trieIndex.dump(os.Stdout)
+
+	// println(trieIndex.countNodes())
+
 	if got, want := trieIndex.allMetrics('.'), []string{
 		"level-0.level-1.level-2-2.memory",
 		"level-0.level-1.cpu",

--- a/deploy/go-carbon.conf
+++ b/deploy/go-carbon.conf
@@ -241,6 +241,14 @@ scan-frequency = "5m0s"
 #  memory usage (by setting both trie-index and trigram-index to true).
 trie-index = false
 
+# Cache file list scan data in the specified path. This option speeds
+# up index building after reboot by reading the last scan result in file
+# system instead of scanning the whole data dir, which could takes up
+# most of the indexing time if it contains a high number of metrics (10
+# - 40 millions). go-carbon only reads the cached file list once after
+# reboot and the cache result is updated after every scan.
+file-list-cache = ""
+
 # Enable concurrently building index without maintaining a new copy
 # index structure. More memory efficient.
 # Currently only trie-index is supported. (EXPERIMENTAL)

--- a/deploy/go-carbon.conf
+++ b/deploy/go-carbon.conf
@@ -241,6 +241,17 @@ scan-frequency = "5m0s"
 #  memory usage (by setting both trie-index and trigram-index to true).
 trie-index = false
 
+# Enable concurrently building index without maintaining a new copy
+# index structure. More memory efficient.
+# Currently only trie-index is supported. (EXPERIMENTAL)
+concurrent-idnex = false
+
+# Set to larger than 0 to enable realtime indexing of new metrics,
+# The value controls how many new metrics could be buffered at once. Suitable to
+# adjust it higher if there are high number of new metrics being produced.
+# Currently only trie-index is supported. (EXPERIMENTAL)
+realtime-index = 0
+
 # This provides the ability to query for new metrics without any wsp files
 # i.e query for metrics present only in cache. Does a cache-scan and
 # populates index with metrics with or without corresponding wsp files,

--- a/deploy/go-carbon.conf
+++ b/deploy/go-carbon.conf
@@ -246,13 +246,13 @@ trie-index = false
 # system instead of scanning the whole data dir, which could takes up
 # most of the indexing time if it contains a high number of metrics (10
 # - 40 millions). go-carbon only reads the cached file list once after
-# reboot and the cache result is updated after every scan.
+# reboot and the cache result is updated after every scan. (EXPERIMENTAL)
 file-list-cache = ""
 
 # Enable concurrently building index without maintaining a new copy
 # index structure. More memory efficient.
 # Currently only trie-index is supported. (EXPERIMENTAL)
-concurrent-idnex = false
+concurrent-index = false
 
 # Set to larger than 0 to enable realtime indexing of new metrics,
 # The value controls how many new metrics could be buffered at once. Suitable to


### PR DESCRIPTION
This is a follow up to https://github.com/lomik/go-carbon/pull/332

With this change, go-carbon no longer requires two versions of trie tree in memory. So memory overhead could be cut down even further in theory. More measurement needed to have some numbers.

This could also make new metrics available in "realtime" without waiting for re-scanning-and-indexing to be finished.