### PR TITLE
Ephemeral nodes for persister (WIP)

### DIFF
--- a/carbon/app.go
+++ b/carbon/app.go
@@ -93,6 +93,13 @@ func (app *App) configure() error {
 		} else {
 			cfg.Whisper.Aggregation = persister.NewWhisperAggregation()
 		}
+
+		if cfg.Whisper.EphemeralFilename != "" {
+			cfg.Whisper.ephemeralFilter, err = persister.NewEphemeralFilter(app.Config.Whisper.DataDir, cfg.Whisper.EphemeralFilename, cfg.Whisper.RecycleThreshold)
+			if err != nil {
+				return err
+			}
+		}
 	}
 	if !(cfg.Cache.WriteStrategy == "max" ||
 		cfg.Cache.WriteStrategy == "sorted" ||
@@ -269,6 +276,7 @@ func (app *App) startPersister() {
 			app.Config.Whisper.DataDir,
 			app.Config.Whisper.Schemas,
 			app.Config.Whisper.Aggregation,
+			app.Config.Whisper.ephemeralFilter,
 			app.Cache.WriteoutQueue().Get,
 			app.Cache.PopNotConfirmed,
 			app.Cache.Confirm,

--- a/carbon/config.go
+++ b/carbon/config.go
@@ -67,7 +67,11 @@ type whisperConfig struct {
 	HashFilenames           bool   `toml:"hash-filenames"`
 	Schemas                 persister.WhisperSchemas
 	Aggregation             *persister.WhisperAggregation
+	ephemeralFilter         *persister.EphemeralFilter
 	RemoveEmptyFile         bool `toml:"remove-empty-file"`
+
+	EphemeralFilename string `toml:"ephemeral-file"`
+	RecycleThreshold  string `toml:"recycle-threshold"`
 }
 
 type cacheConfig struct {

--- a/persister/ephemeral.go
+++ b/persister/ephemeral.go
@@ -1,0 +1,132 @@
+package persister
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+type ephemeralMatcher struct {
+	idx   int
+	nodes []string
+}
+
+type EphemeralFilter struct {
+	home             string
+	matchers         []ephemeralMatcher
+	recycleThreshold time.Duration
+}
+
+const ephemeralNode = "$ephemeral"
+
+func NewEphemeralFilter(home, filename string, recycleThreshold string) (*EphemeralFilter, error) {
+	config, err := parseIniFile(filename)
+	if err != nil {
+		return nil, err
+	}
+
+	var ef EphemeralFilter
+	ef.home = home
+	ef.recycleThreshold, err = time.ParseDuration(recycleThreshold)
+	if err != nil {
+		return nil, fmt.Errorf("[persister] Failed to parse recycle-threshold %q", recycleThreshold)
+	}
+	for _, e := range config {
+		p := e["pattern"]
+		if p == "" {
+			return nil, fmt.Errorf("[persister] Empty pattern in section %q", e["name"])
+		}
+		var em ephemeralMatcher
+		em.idx = -1
+		for i, n := range strings.Split(p, ".") {
+			if n != ephemeralNode {
+				em.nodes = append(em.nodes, n)
+				continue
+			}
+
+			if em.idx != -1 {
+				return nil, fmt.Errorf("[persister] Multiple %q found in pattern of section %q", ephemeralNode, e["name"])
+			}
+			em.idx = i
+			em.nodes = append(em.nodes, "*")
+		}
+		if em.idx == -1 {
+			return nil, fmt.Errorf("[persister] %q not found in pattern of section %q", ephemeralNode, e["name"])
+		}
+		ef.matchers = append(ef.matchers, em)
+	}
+
+	return &ef, nil
+}
+
+// TODO: checks issues filepath.Glob and os.Stat calls, which could be
+// optimized away with trie index (if we include a modification
+// timestamp on file nodes) if enabled.
+func (ef *EphemeralFilter) check(metric string) (matched bool, path string, err error) {
+	mns := strings.Split(metric, ".")
+
+mloop:
+	for _, em := range ef.matchers {
+		if len(em.nodes) > len(mns) {
+			continue
+		}
+		for i, n := range mns {
+			if i >= len(em.nodes) {
+				break
+			}
+			if em.nodes[i] == "*" || em.nodes[i] == n {
+				continue
+			}
+
+			continue mloop
+		}
+
+		// TODO: handle em.idx == 0
+		prefix := filepath.Join(append(append([]string{}, ef.home), mns[:em.idx]...)...)
+		for i, n := range em.nodes {
+			if n == "*" {
+				mns[i] = "*"
+			}
+		}
+
+		var matches []string
+		matches, err = filepath.Glob(filepath.Join(append(append([]string{}, ef.home), mns...)...))
+		if err != nil {
+			return
+		}
+
+		// prefer matches that have the same prefix as the target metric
+		var idx int
+		for i := 0; i < len(matches); i++ {
+			if !strings.HasPrefix(matches[i], prefix) {
+				continue
+			}
+			tmp := matches[idx]
+			matches[idx] = matches[i]
+			matches[i] = tmp
+			idx++
+		}
+
+		now := time.Now()
+		for _, p := range matches {
+			var stat os.FileInfo
+			stat, err = os.Stat(p)
+			if err != nil {
+				return
+			}
+
+			// TODO: support more complex recycle policy
+			if now.Sub(stat.ModTime()) >= ef.recycleThreshold {
+				path = p
+				matched = true
+				return
+			}
+		}
+
+		return
+	}
+
+	return
+}

--- a/persister/ephemeral_test.go
+++ b/persister/ephemeral_test.go
@@ -1,0 +1,90 @@
+package persister
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestEphemeralCheck(t *testing.T) {
+	defer func() {
+		if err := os.RemoveAll("testdata"); err != nil {
+			t.Fatal(err)
+		}
+	}()
+
+	newFile("testdata/ns1/ns0/e1/cpu.wsp", time.Minute)
+	newFile("testdata/ns1/ns2/e1/cpu.wsp", time.Minute)
+	newFile("testdata/ns1/ns2/e2/cpu.wsp", time.Hour*2)
+	newFile("testdata/ns1/ns3/e3/cpu.wsp", time.Minute)
+	newFile("testdata/ns3/ns3/e3/cpu.wsp", time.Minute)
+
+	newFile("testdata/ephemeral.conf", 0)
+	ioutil.WriteFile("testdata/ephemeral.conf", []byte(`
+		[sys]
+			pattern = ns1.*.$ephemeral.*
+		[sys2]
+			pattern = ns3.*.$ephemeral.*
+	`), 0644)
+
+	ef, err := newEphemeralFilter("testdata", "testdata/ephemeral.conf", time.Hour)
+	if err != nil {
+		t.Error(err)
+	}
+
+	{
+		t.Log("replace older file")
+		matched, path, err := ef.check("ns1.ns2.e3.cpu")
+		if err != nil {
+			t.Error(err)
+		}
+		if got, want := matched, true; got != want {
+			t.Errorf("matched = %t; want %t", got, want)
+		}
+		if got, want := path, "testdata/ns1/ns2/e2/cpu.wsp"; got != want {
+			t.Errorf("path = %s; want %s", got, want)
+		}
+	}
+	{
+		t.Log("ignore unmatched pattern")
+		matched, path, err := ef.check("ns2.ns2.e3.cpu")
+		if err != nil {
+			t.Error(err)
+		}
+		if got, want := matched, false; got != want {
+			t.Errorf("matched = %t; want %t", got, want)
+		}
+		if got, want := path, ""; got != want {
+			t.Errorf("path = %s; want %s", got, want)
+		}
+	}
+
+	{
+		t.Log("do not return new file")
+		matched, path, err := ef.check("ns3.ns0.e2.cpu")
+		if err != nil {
+			t.Error(err)
+		}
+		if got, want := matched, false; got != want {
+			t.Errorf("matched = %t; want %t", got, want)
+		}
+		if got, want := path, ""; got != want {
+			t.Errorf("path = %s; want %s", got, want)
+		}
+	}
+}
+
+func newFile(p string, mtime time.Duration) {
+	if err := os.MkdirAll(filepath.Dir(p), 0777); err != nil {
+		panic(err)
+	}
+
+	if _, err := os.Create(p); err != nil {
+		panic(err)
+	}
+	if err := os.Chtimes(p, time.Now().Add(-1*mtime), time.Now().Add(-1*mtime)); err != nil {
+		panic(err)
+	}
+}

--- a/persister/whisper.go
+++ b/persister/whisper.go
@@ -54,6 +54,7 @@ type Whisper struct {
 	mockStore               func() (StoreFunc, func())
 	logger                  *zap.Logger
 	createLogger            *zap.Logger
+	ephemeralFilter         *ephemeralFilter
 	// blockThrottleNs        uint64 // sum ns counter
 	// blockQueueGetNs        uint64 // sum ns counter
 	// blockAvoidConcurrentNs uint64 // sum ns counter
@@ -65,10 +66,11 @@ func NewWhisper(
 	rootPath string,
 	schemas WhisperSchemas,
 	aggregation *WhisperAggregation,
+	ephemeralFilter *EphemeralFilter,
 	recv func(chan bool) string,
 	pop func(string) (*points.Points, bool),
 	confirm func(*points.Points),
-	popConfirm func(string) (*points.Points, bool)) *Whisper {
+	popConfirm func(string) (*points.Points, bool)) (*Whisper, error) {
 
 	return &Whisper{
 		recv:                recv,
@@ -77,6 +79,7 @@ func NewWhisper(
 		popConfirm:          popConfirm,
 		schemas:             schemas,
 		aggregation:         aggregation,
+		ephemeralFilter:     ephemeralFilter,
 		workersCount:        1,
 		rootPath:            rootPath,
 		maxUpdatesPerSecond: 0,


### PR DESCRIPTION
Early preview of my yet another idea for go-carbon/go-graphite.

Pods comes and goes quickly on kubernetes and this creates issue for monitoring it with Graphite. Long term metrics is hard to be accommodated because most of the pods don't live long enough, thus preallocation of big metric file becomes too expensive.

This merge request attempts to **mitigate** the issue by reusing old and relevant metric files belongs to the same deployment/application/service by reusing old metric files.

For example, if an application have 3 pods, and each pod generates some metrics for cpu/memory/requests.

with this ephemeral node configuration:

```
k8s.*.$ephemeral.*
```

existing files in data dir:

```
k8s/app1/pod-id-01/cpu.wsp --> old file
k8s/app1/pod-id-02/cpu.wsp --> current file
k8s/app1/pod-id-02/mem.wsp
k8s/app2/pod-id-02/cpu.wsp
```

When a new cpu metric for a new pod for app1 is produced, go-carbon would check if there is old metric file for the same metric. If there is, instead of creating a new metric file, it would pick it up and reuse it. Note: it won't reset the file, it would only rename it and keep the history.

So for the above example, when a new metics named k8s.app1.pod-id-03.cpu comes in, go-carbon would rename k8s/app1/pod-id-01/cpu.wsp to k8s/app1/pod-id-03/cpu.wsp

Pros:

* long term history for short-lived pod metrics
* less stress on disk usage

Cons:

* if rollouts are too frequent, shorter than recycle threshold, then new files would still be generated

Codes still incomplete and production validation still needed. Just preview.