### PR TITLE
carbonserver: fix broken benchmark tests

### DIFF
--- a/carbonserver/carbonserver_test.go
+++ b/carbonserver/carbonserver_test.go
@@ -419,11 +419,10 @@ func benchmarkFetchSingleMetricCommon(b *testing.B, test *FetchTest) {
 	test.path = path
 	cache := cache.New()
 
-	carbonserver := CarbonserverListener{
-		whisperData: test.path,
-		cacheGet:    cache.Get,
-		metrics:     &metricStruct{},
-	}
+	carbonserver := NewCarbonserverListener(cache.Get)
+	carbonserver.whisperData = path
+	carbonserver.logger = zap.NewNop()
+	carbonserver.metrics = &metricStruct{}
 	// common
 
 	// Non-existing metric
@@ -435,7 +434,7 @@ func benchmarkFetchSingleMetricCommon(b *testing.B, test *FetchTest) {
 
 	b.ResetTimer()
 	for runs := 0; runs < b.N; runs++ {
-		data, err := generalFetchSingleMetricHelper(test, cache, &carbonserver)
+		data, err := generalFetchSingleMetricHelper(test, cache, carbonserver)
 		if err != nil {
 			b.Errorf("Unexpected error: %v", err)
 			return


### PR DESCRIPTION
BenchMarks in carbonserver_test.go are broken.
```
➜  go-carbon git:(96dd8d5) go test -v github.com/lomik/go-carbon/carbonserver -run=none -bench=BenchmarkFetch

panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x13b1e05]

goroutine 13 [running]:
github.com/lomik/go-carbon/vendor/go.uber.org/zap.(*Logger).clone(...)
        /Users/praneeth_bigleaf/Bigleaf/go/src/oup/go-carbon/_vendor/src/github.com/lomik/go-carbon/vendor/go.uber.org/zap/logger.go:252
github.com/lomik/go-carbon/vendor/go.uber.org/zap.(*Logger).With(0x0, 0xc000178000, 0x3, 0x3, 0x0)
        /Users/praneeth_bigleaf/Bigleaf/go/src/oup/go-carbon/_vendor/src/github.com/lomik/go-carbon/vendor/go.uber.org/zap/logger.go:163 +0x45
github.com/lomik/go-carbon/carbonserver.(*CarbonserverListener).fetchSingleMetric(0xc0001c5c50, 0x16de5dc, 0x9, 0x0, 0x0, 0x5e5855305e585404, 0x0, 0x0, 0x0, 0x0, ...)
        /Users/praneeth_bigleaf/Bigleaf/go/src/oup/go-carbon/_vendor/src/github.com/lomik/go-carbon/carbonserver/fetchsinglemetric.go:93 +0x39b
github.com/lomik/go-carbon/carbonserver.(*CarbonserverListener).fetchSingleMetricV2(0xc0001c5c50, 0x16de5dc, 0x9, 0x5e5855305e585404, 0xc00002c180, 0x3a, 0x0)
        /Users/praneeth_bigleaf/Bigleaf/go/src/oup/go-carbon/_vendor/src/github.com/lomik/go-carbon/carbonserver/fetchsinglemetric.go:140 +0x7b
github.com/lomik/go-carbon/carbonserver.generalFetchSingleMetricHelper(...)
        /Users/praneeth_bigleaf/Bigleaf/go/src/oup/go-carbon/_vendor/src/github.com/lomik/go-carbon/carbonserver/carbonserver_test.go:116
github.com/lomik/go-carbon/carbonserver.benchmarkFetchSingleMetricCommon(0xc000154000, 0xc000144840)
        /Users/praneeth_bigleaf/Bigleaf/go/src/oup/go-carbon/_vendor/src/github.com/lomik/go-carbon/carbonserver/carbonserver_test.go:438 +0x332
github.com/lomik/go-carbon/carbonserver.BenchmarkFetchSingleMetricDataFile(0xc000154000)
        /Users/praneeth_bigleaf/Bigleaf/go/src/oup/go-carbon/_vendor/src/github.com/lomik/go-carbon/carbonserver/carbonserver_test.go:454 +0x4e
testing.(*B).runN(0xc000154000, 0x1)
        /usr/local/go/src/testing/benchmark.go:190 +0xcc
testing.(*B).run1.func1(0xc000154000)
        /usr/local/go/src/testing/benchmark.go:230 +0x64
created by testing.(*B).run1
        /usr/local/go/src/testing/benchmark.go:223 +0x7d
exit status 2
FAIL    github.com/lomik/go-carbon/carbonserver 0.018s
FAIL
```

Fix initializes carbonserver as per https://github.com/lomik/go-carbon/commit/19b1ecf9223964354c92c68435cf3ed53d49c3d9
