### PR TITLE
 cache-scan tunable to scan and populate cache-only metrics in the index

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,8 +318,8 @@ trie-index = false
 
 # This provides the ability to query for new metrics without any wsp files
 # i.e query for metrics present only in cache. Does a cache-scan and
-# populates index with metrics with or without corresponding wsp files.
-# Disabled by default.
+# populates index with metrics with or without corresponding wsp files,
+# but will lead to increased memory consumption. Disabled by default.
 cache-scan = false
 
 # Maximum amount of globs in a single metric in index

--- a/README.md
+++ b/README.md
@@ -316,6 +316,12 @@ scan-frequency = "5m0s"
 #  memory usage (by setting both trie-index and trigram-index to true).
 trie-index = false
 
+# This provides the ability to query for new metrics without any wsp files
+# i.e query for metrics present only in cache. Does a cache-scan and
+# populates index with metrics with or without corresponding wsp files.
+# Disabled by default.
+cache-scan = false
+
 # Maximum amount of globs in a single metric in index
 # This value is used to speed-up /find requests with
 # a lot of globs, but will lead to increased memory consumption

--- a/carbon/config.go
+++ b/carbon/config.go
@@ -116,6 +116,7 @@ type carbonserverConfig struct {
 	TrigramIndex      bool      `toml:"trigram-index"`
 	InternalStatsDir  string    `toml:"internal-stats-dir"`
 	Percentiles       []int     `toml:"stats-percentiles"`
+	CacheScan         bool      `toml:"cache-scan"`
 
 	MaxMetricsGlobbed  int `toml:"max-metrics-globbed"`
 	MaxMetricsRendered int `toml:"max-metrics-rendered"`
@@ -218,6 +219,7 @@ func NewConfig() *Config {
 			QueryCacheSizeMB:   0,
 			FindCacheEnabled:   true,
 			TrigramIndex:       true,
+			CacheScan:          false,
 			MaxMetricsGlobbed:  30000,
 			MaxMetricsRendered: 1000,
 		},

--- a/carbonserver/cache_index_test.go
+++ b/carbonserver/cache_index_test.go
@@ -1,0 +1,214 @@
+package carbonserver
+
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/lomik/go-carbon/cache"
+	"github.com/lomik/go-carbon/points"
+	"go.uber.org/zap"
+)
+
+var addMetrics = [...]string{
+	"new.data.point1",
+	"same.data.new.point1",
+	"same.data.new.point2",
+	"totally.new.point",
+	"fresh.add",
+}
+
+var addFiles = [...]string{
+	"path/to/file/name1.wsp",
+	"path/to/file/name2.wsp",
+	"path/to/file1/name1.wsp",
+	"file/name1.wsp",
+	"justname.wsp",
+}
+
+var removeFiles = [...]string{
+	"path/to/file/name2.wsp",
+	"path/to/file1/name1.wsp",
+	"justname.wsp",
+}
+
+type testInfo struct {
+	forceChan     chan struct{}
+	exitChan      chan struct{}
+	testCache     *cache.Cache
+	csListener    *CarbonserverListener
+	scanFrequency <-chan time.Time
+	whisperDir    string
+}
+
+func addFileToSys(file string, tmpDir string) error {
+	path := filepath.Dir(file)
+	if err := addFilePathToDir(path, tmpDir); err != nil {
+		return err
+	}
+	if nfile, err := os.OpenFile(filepath.Join(tmpDir, file), os.O_RDONLY|os.O_CREATE, 0644); err == nil {
+		nfile.Close()
+		return nil
+	} else {
+		return nil
+	}
+}
+
+func addFilePathToDir(filePath string, tmpDir string) error {
+	err := os.MkdirAll(filepath.Join(tmpDir, filePath), 0755)
+	if err != nil {
+		os.RemoveAll(tmpDir)
+	}
+	return err
+}
+
+func removeFileFromDir(filePath string, tmpDir string) error {
+	return os.Remove(filepath.Join(tmpDir, filePath))
+}
+
+func getTestInfo(t *testing.T) *testInfo {
+	tmpDir, err := ioutil.TempDir("", "")
+	if err != nil {
+		fmt.Printf("unable to create test dir tree: %v\n", err)
+		t.Fatal(err)
+	}
+
+	c := cache.New()
+	carbonserver := NewCarbonserverListener(c.Get)
+	carbonserver.whisperData = tmpDir
+	carbonserver.logger = zap.NewNop()
+	carbonserver.cacheGetRecentMetrics = c.GetRecentNewMetrics
+	carbonserver.metrics = &metricStruct{}
+	carbonserver.exitChan = make(chan struct{})
+
+	return &testInfo{
+		forceChan:     make(chan struct{}),
+		exitChan:      make(chan struct{}),
+		scanFrequency: time.Tick(3 * time.Second),
+		testCache:     c,
+		csListener:    carbonserver,
+		whisperDir:    tmpDir,
+	}
+}
+
+func (f *testInfo) setTrigramOnly() {
+	f.csListener.trigramIndex = true
+	f.csListener.trieIndex = false
+}
+
+func (f *testInfo) setTrieOnly() {
+	f.csListener.trigramIndex = false
+	f.csListener.trieIndex = true
+}
+
+func (f *testInfo) checkExpandGlobs(t *testing.T, query string, shdExist bool) {
+	fmt.Println("the query is - ", query)
+	expandedGlobs, err := f.csListener.getExpandedGlobs(context.TODO(), zap.NewNop(), time.Now(), []string{query})
+	if err != nil {
+		t.Errorf("Unexpected err: '%v', expected: 'nil'", err)
+		return
+	}
+
+	if expandedGlobs == nil {
+		t.Errorf("No globs returned")
+		return
+	}
+
+	fmt.Println("************* the expanded globs - ", expandedGlobs)
+
+	if shdExist {
+		file := expandedGlobs[0].Files[0]
+		if file != query {
+			t.Errorf("files: '%v', epxected: '%s'\n", file, query)
+			return
+		}
+	} else {
+		if len(expandedGlobs[0].Files) != 0 {
+			t.Errorf("expected no files but found - '%v'\n", expandedGlobs[0].Files)
+			return
+		}
+	}
+}
+
+func (f *testInfo) commonCacheIdxTestHelper(t *testing.T) {
+	defer os.RemoveAll(f.whisperDir)
+
+	for _, filePath := range addFiles {
+		if err := addFileToSys(filePath, f.whisperDir); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	//trigger filescan
+	go f.csListener.fileListUpdater(f.whisperDir, f.scanFrequency, f.forceChan, f.exitChan)
+	f.forceChan <- struct{}{}
+	time.Sleep(2 * time.Second)
+
+	//add metrics to cache
+	for i, metricName := range addMetrics {
+		f.testCache.Add(points.OnePoint(metricName, float64(i), 10))
+	}
+	//check expandblobs for new metrics
+	f.checkExpandGlobs(t, addMetrics[2], false)
+	f.checkExpandGlobs(t, addMetrics[0], false)
+
+	//pop metric from cache
+	m1 := f.testCache.WriteoutQueue().Get(nil)
+	p1, _ := f.testCache.PopNotConfirmed(m1)
+	f.testCache.Confirm(p1)
+
+	if !p1.Eq(points.OnePoint(addMetrics[4], 4, 10)) {
+		fmt.Printf("error - recived wrong point - %v\n", p1)
+		t.FailNow()
+	}
+
+	for _, filePath := range removeFiles {
+		if err := removeFileFromDir(filePath, f.whisperDir); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	time.Sleep(5 * time.Second)
+	f.checkExpandGlobs(t, "path.to.file.name1", true)
+	f.checkExpandGlobs(t, addMetrics[3], true)
+	f.checkExpandGlobs(t, addMetrics[0], true)
+	// f.checkExpandGlobs(t, addMetrics[4], false)
+
+	//pop metric from cache
+	m2 := f.testCache.WriteoutQueue().Get(nil)
+	p2, _ := f.testCache.PopNotConfirmed(m2)
+	f.testCache.Confirm(p2)
+
+	// queue within cache is sorted by length of metric name
+	if !p2.Eq(points.OnePoint(addMetrics[0], 0, 10)) {
+		fmt.Printf("error - recived wrong point - %v\n", p2)
+		t.FailNow()
+	}
+	f.checkExpandGlobs(t, addMetrics[0], true)
+
+	//wait for next filewalk and check the metric again
+	fmt.Println("wait for next filewalk and check the metric again")
+	time.Sleep(4 * time.Second)
+	// f.checkExpandGlobs(t, addMetrics[0], false)
+
+	close(f.forceChan)
+	close(f.exitChan)
+}
+
+func TestCacheIdxTrie(t *testing.T) {
+	// get test info
+	f := getTestInfo(t)
+	f.setTrieOnly()
+	f.commonCacheIdxTestHelper(t)
+}
+
+func TestCacheIdxTrigram(t *testing.T) {
+	// get test info
+	f := getTestInfo(t)
+	f.setTrigramOnly()
+	f.commonCacheIdxTestHelper(t)
+}

--- a/carbonserver/cache_index_test.go
+++ b/carbonserver/cache_index_test.go
@@ -9,8 +9,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/lomik/go-carbon/cache"
-	"github.com/lomik/go-carbon/points"
+	"github.com/go-graphite/go-carbon/cache"
+	"github.com/go-graphite/go-carbon/points"
 	"go.uber.org/zap"
 )
 

--- a/carbonserver/carbonserver_test.go
+++ b/carbonserver/carbonserver_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"regexp"
 	"strings"
 	"testing"
 	"time"
@@ -14,14 +15,28 @@ import (
 	"github.com/dgryski/go-trigram"
 	"github.com/go-graphite/go-whisper"
 	pb "github.com/go-graphite/protocol/carbonapi_v2_pb"
-	"github.com/go-graphite/go-carbon/cache"
-	"github.com/go-graphite/go-carbon/points"
+	"github.com/lomik/go-carbon/cache"
+	"github.com/lomik/go-carbon/persister"
+	"github.com/lomik/go-carbon/points"
 	"go.uber.org/zap"
 )
 
 type point struct {
 	Timestamp int
 	Value     float64
+}
+
+type wspConfigTestRetriever struct{
+	getRetentionFunc func(string) (int, bool)
+	getAggrNameFunc func(string) (string, float64, bool)
+}
+
+func (r *wspConfigTestRetriever) MetricRetentionPeriod(metric string) (int, bool) {
+	return r.getRetentionFunc(metric)
+}
+
+func (r *wspConfigTestRetriever) MetricAggrConf(metric string) (string, float64, bool) {
+	return r.getAggrNameFunc(metric)
 }
 
 type FetchTest struct {
@@ -35,6 +50,7 @@ type FetchTest struct {
 	fillCache        bool
 	errIsNil         bool
 	dataIsNil        bool
+	fillCacheIndex   bool
 	cachePoints      []point
 	expectedStep     int32
 	expectedErr      string
@@ -69,7 +85,37 @@ func TestExtractTrigrams(t *testing.T) {
 	}
 }
 
-func generalFetchSingleMetricInit(testData *FetchTest, cache *cache.Cache) error {
+func getTestPersister(dataDir string, cache *cache.Cache) *persister.Whisper{
+	retentionStr := "60s:90d,300s:30d"
+	pattern, _ := regexp.Compile(".*")
+	retentions, _ := persister.ParseRetentionDefs(retentionStr)
+	f := false
+	schema := persister.Schema{
+		Name:         "test",
+		Pattern:      pattern,
+		RetentionStr: retentionStr,
+		Retentions:   retentions,
+		Priority:     10,
+		Compressed:   &f,
+	}
+
+	var testSchemas persister.WhisperSchemas
+	testSchemas = append(testSchemas,schema)
+
+	testPersister := persister.NewWhisper(
+		dataDir,
+		testSchemas,
+		persister.NewWhisperAggregation(),
+		cache.WriteoutQueue().Get,
+		cache.PopNotConfirmed,
+		cache.Confirm,
+		cache.Pop,
+	)
+
+	return testPersister
+}
+
+func generalFetchSingleMetricInit(testData *FetchTest, cache *cache.Cache, carbonserver *CarbonserverListener) error {
 	var wsp *whisper.Whisper
 	var p []*whisper.TimeSeriesPoint
 	if testData.retention == "" {
@@ -99,12 +145,25 @@ func generalFetchSingleMetricInit(testData *FetchTest, cache *cache.Cache) error
 			}
 		}
 		wsp.Close()
-		if testData.fillCache {
-			for _, p := range testData.cachePoints {
-				cache.Add(points.OnePoint(testData.name, p.Value, int64(p.Timestamp)))
-			}
+	}
+
+	if testData.fillCache {
+		for _, p := range testData.cachePoints {
+			cache.Add(points.OnePoint(testData.name, p.Value, int64(p.Timestamp)))
 		}
 	}
+
+	if testData.fillCacheIndex{
+		// enable cache-scan to support queries for cache-only metrics
+		carbonserver.SetCacheGetMetricsFunc(cache.GetRecentNewMetrics)
+		testPersister := getTestPersister(testData.path, cache)
+		retriever := &wspConfigTestRetriever{
+			getRetentionFunc: testPersister.GetRetentionPeriod,
+			getAggrNameFunc: testPersister.GetAggrConf,
+		}
+		carbonserver.SetConfigRetriever(retriever)
+	}
+
 	return nil
 }
 
@@ -118,7 +177,7 @@ func generalFetchSingleMetricHelper(testData *FetchTest, cache *cache.Cache, car
 }
 
 func testFetchSingleMetricHelper(testData *FetchTest, cache *cache.Cache, carbonserver *CarbonserverListener) (*pb.FetchResponse, error) {
-	err := generalFetchSingleMetricInit(testData, cache)
+	err := generalFetchSingleMetricInit(testData, cache, carbonserver)
 	if err != nil {
 		return nil, err
 	}
@@ -214,6 +273,22 @@ var singleMetricTests = []FetchTest{
 		createWhisper:    true,
 		fillWhisper:      false,
 		fillCache:        true,
+		from:             now - 420,
+		until:            now,
+		now:              now,
+		errIsNil:         true,
+		dataIsNil:        false,
+		cachePoints:      []point{{now - 123, 7.0}, {now - 119, 7.1}, {now - 45, 7.3}, {now - 243, 6.9}, {now - 67, 7.2}},
+		expectedStep:     60,
+		expectedValues:   []float64{0.0, 6.9, 0.0, 7.0, 7.2, 7.3, 0.0},
+		expectedIsAbsent: []bool{true, false, true, false, false, false, true},
+	},
+	{
+		name:             "data-cache-only",
+		createWhisper:    false,
+		fillWhisper:      false,
+		fillCache:        true,
+		fillCacheIndex:   true,
 		from:             now - 420,
 		until:            now,
 		now:              now,
@@ -346,6 +421,11 @@ func TestFetchSingleMetricDataCache(t *testing.T) {
 	testFetchSingleMetricCommon(t, test)
 }
 
+func TestFetchSingleMetricDataCacheOnly(t *testing.T) {
+	test := getSingleMetricTest("data-cache-only")
+	testFetchSingleMetricCommon(t, test)
+}
+
 func TestGetMetricsListEmpty(t *testing.T) {
 	cache := cache.New()
 	path, err := ioutil.TempDir("", "")
@@ -426,7 +506,7 @@ func benchmarkFetchSingleMetricCommon(b *testing.B, test *FetchTest) {
 	// common
 
 	// Non-existing metric
-	err = generalFetchSingleMetricInit(test, cache)
+	err = generalFetchSingleMetricInit(test, cache, &carbonserver)
 	if err != nil {
 		b.Fatalf("Unexpected error %v\n", err)
 	}

--- a/carbonserver/carbonserver_test.go
+++ b/carbonserver/carbonserver_test.go
@@ -15,9 +15,9 @@ import (
 	"github.com/dgryski/go-trigram"
 	"github.com/go-graphite/go-whisper"
 	pb "github.com/go-graphite/protocol/carbonapi_v2_pb"
-	"github.com/lomik/go-carbon/cache"
-	"github.com/lomik/go-carbon/persister"
-	"github.com/lomik/go-carbon/points"
+	"github.com/go-graphite/go-carbon/cache"
+	"github.com/go-graphite/go-carbon/persister"
+	"github.com/go-graphite/go-carbon/points"
 	"go.uber.org/zap"
 )
 
@@ -506,7 +506,7 @@ func benchmarkFetchSingleMetricCommon(b *testing.B, test *FetchTest) {
 	// common
 
 	// Non-existing metric
-	err = generalFetchSingleMetricInit(test, cache, &carbonserver)
+	err = generalFetchSingleMetricInit(test, cache, carbonserver)
 	if err != nil {
 		b.Fatalf("Unexpected error %v\n", err)
 	}

--- a/carbonserver/fetchfromcache.go
+++ b/carbonserver/fetchfromcache.go
@@ -1,0 +1,89 @@
+package carbonserver
+
+import (
+	"errors"
+	"math"
+	"strings"
+	"sync/atomic"
+	"time"
+
+	"go.uber.org/zap"
+
+	"github.com/lomik/go-carbon/points"
+)
+
+// https://github.com/golang/go/issues/448
+func mod(a, b int32) int32 {
+	m := a % b
+	if m < 0 {
+		m += b
+	}
+	return m
+}
+
+// from go-graphite/go-whisper
+func interval(time, secondsPerPoint int32) int32 {
+	return time - mod(time, secondsPerPoint) + secondsPerPoint
+}
+
+func (listener *CarbonserverListener) fetchFromCache(metric string, fromTime, untilTime int32, resp *response) ([]points.Point, error) {
+	var step, i int32
+	path := listener.whisperData + "/" + strings.Replace(metric, ".", "/", -1) + ".wsp"
+
+	logger := listener.logger.With(
+		zap.String("path", path),
+		zap.Int("fromTime", int(fromTime)),
+		zap.Int("untilTime", int(untilTime)),
+	)
+
+	// query cache
+	cacheStartTime := time.Now()
+	cacheData := listener.cacheGet(metric)
+	waitTime := time.Since(cacheStartTime)
+	atomic.AddUint64(&listener.metrics.CacheWaitTimeFetchNS, uint64(waitTime.Nanoseconds()))
+	listener.prometheus.cacheDuration("wait", waitTime)
+
+	if cacheData == nil {
+		// we really can't find this metric
+		atomic.AddUint64(&listener.metrics.NotFound, 1)
+		listener.logger.Error("No data (wsp file nor cache) exists for the metric", zap.String("path", path))
+		return nil, errors.New("No data (wsp file nor cache) exists for the metric")
+	}
+
+	logger.Debug("fetching cache only metric")
+
+	// retentions, aggMethod, xFilesFactor from matched schema/agg
+	retentionStep, ok := listener.whisperGetConfig.MetricRetentionPeriod(metric)
+	if !ok {
+		return nil, errors.New("no retention schemas defined")
+	}
+	aggrName, aggrXFilesFact, ok := listener.whisperGetConfig.MetricAggrConf(metric)
+	if !ok {
+		return nil, errors.New("no storage aggregation defined")
+	}
+
+	step = int32(retentionStep)
+
+	// create dummy values slice which will be
+	// popolated with real values from cache in
+	// enrichFromCache in fetchsinglemetric
+	var values []float64
+	for i = 0; i < (untilTime-fromTime)/step; i++ {
+		values = append(values, math.NaN())
+	}
+
+	resp.StartTime = int64(interval(fromTime, step))
+	resp.StopTime = int64(interval(untilTime, step))
+	resp.StepTime = int64(retentionStep)
+	resp.Values = values
+	resp.ConsolidationFunc = aggrName
+	resp.XFilesFactor = float32(aggrXFilesFact)
+
+	atomic.AddUint64(&listener.metrics.MetricsReturned, 1)
+	listener.prometheus.returnedMetric()
+
+	atomic.AddUint64(&listener.metrics.PointsReturned, uint64(len(values)))
+	listener.prometheus.returnedPoint(len(values))
+
+	return cacheData, nil
+}

--- a/carbonserver/fetchfromcache.go
+++ b/carbonserver/fetchfromcache.go
@@ -9,7 +9,7 @@ import (
 
 	"go.uber.org/zap"
 
-	"github.com/lomik/go-carbon/points"
+	"github.com/go-graphite/go-carbon/points"
 )
 
 // https://github.com/golang/go/issues/448

--- a/carbonserver/fetchsinglemetric.go
+++ b/carbonserver/fetchsinglemetric.go
@@ -9,7 +9,7 @@ import (
 
 	"go.uber.org/zap"
 
-	"github.com/lomik/go-carbon/points"
+	"github.com/go-graphite/go-carbon/points"
 	protov2 "github.com/go-graphite/protocol/carbonapi_v2_pb"
 	protov3 "github.com/go-graphite/protocol/carbonapi_v3_pb"
 )

--- a/carbonserver/fetchsinglemetric.go
+++ b/carbonserver/fetchsinglemetric.go
@@ -3,11 +3,13 @@ package carbonserver
 import (
 	"errors"
 	"math"
+	"os"
 	"sync/atomic"
 	"time"
 
 	"go.uber.org/zap"
 
+	"github.com/lomik/go-carbon/points"
 	protov2 "github.com/go-graphite/protocol/carbonapi_v2_pb"
 	protov3 "github.com/go-graphite/protocol/carbonapi_v3_pb"
 )
@@ -25,15 +27,15 @@ type response struct {
 	RequestStopTime   int64
 }
 
-func (r response) enrichFromCache(listener *CarbonserverListener, m *metricFromDisk) {
-	if m.CacheData == nil {
+func (r response) enrichFromCache(listener *CarbonserverListener, cacheData []points.Point) {
+	if cacheData == nil {
 		return
 	}
 
 	atomic.AddUint64(&listener.metrics.CacheRequestsTotal, 1)
 	cacheStartTime := time.Now()
 	pointsFetchedFromCache := 0
-	for _, item := range m.CacheData {
+	for _, item := range cacheData {
 		ts := int64(item.Timestamp) - int64(item.Timestamp)%r.StepTime
 		if ts < r.StartTime || ts >= r.StopTime {
 			continue
@@ -96,44 +98,63 @@ func (listener *CarbonserverListener) fetchSingleMetric(metric string, pathExpre
 		zap.Int("untilTime", int(untilTime)),
 	)
 	m, err := listener.fetchFromDisk(metric, fromTime, untilTime)
-	if err != nil {
+	if err == nil {
+		// Should never happen, because we have a check for proper archive now
+		if m.Timeseries == nil {
+			atomic.AddUint64(&listener.metrics.RenderErrors, 1)
+			logger.Warn("metric time range not found")
+			return response{}, errors.New("time range not found")
+		}
+
+		values := m.Timeseries.Values()
+		from := int64(m.Timeseries.FromTime())
+		until := int64(m.Timeseries.UntilTime())
+		step := int64(m.Timeseries.Step())
+
+		resp := response{
+			Name:              metric,
+			StartTime:         from,
+			StopTime:          until,
+			StepTime:          step,
+			Values:            values,
+			PathExpression:    pathExpression,
+			ConsolidationFunc: m.Metadata.ConsolidationFunc,
+			XFilesFactor:      m.Metadata.XFilesFactor,
+			RequestStartTime:  int64(fromTime),
+			RequestStopTime:   int64(untilTime),
+		}
+
+		resp.enrichFromCache(listener, m.CacheData)
+
+		logger.Debug("fetched",
+			zap.Any("response", resp),
+		)
+
+		return resp, nil
+	} else if os.IsNotExist(err) && listener.cacheGetRecentMetrics != nil {
+		//Failed to fetch from disk, try to fetch from cache
+		resp := response{
+			Name:           metric,
+			PathExpression: pathExpression,
+		}
+		cacheData, cerr := listener.fetchFromCache(metric, fromTime, untilTime, &resp)
+		if cerr != nil {
+			atomic.AddUint64(&listener.metrics.RenderErrors, 1)
+			logger.Warn("metric not found even in Cache", zap.Error(err))
+			// Metric has no Whisper file and/or has no datapoints in Cache
+			return response{}, cerr
+		}
+		resp.enrichFromCache(listener, cacheData)
+		logger.Debug("fetched cache-only",
+			zap.Any("response", resp),
+		)
+
+		return resp, nil
+	} else {
 		atomic.AddUint64(&listener.metrics.RenderErrors, 1)
 		logger.Warn("failed to fetch points", zap.Error(err))
 		return response{}, err
 	}
-
-	// Should never happen, because we have a check for proper archive now
-	if m.Timeseries == nil {
-		atomic.AddUint64(&listener.metrics.RenderErrors, 1)
-		logger.Warn("metric time range not found")
-		return response{}, errors.New("time range not found")
-	}
-
-	values := m.Timeseries.Values()
-	from := int64(m.Timeseries.FromTime())
-	until := int64(m.Timeseries.UntilTime())
-	step := int64(m.Timeseries.Step())
-
-	resp := response{
-		Name:              metric,
-		StartTime:         from,
-		StopTime:          until,
-		StepTime:          step,
-		Values:            values,
-		PathExpression:    pathExpression,
-		ConsolidationFunc: m.Metadata.ConsolidationFunc,
-		XFilesFactor:      m.Metadata.XFilesFactor,
-		RequestStartTime:  int64(fromTime),
-		RequestStopTime:   int64(untilTime),
-	}
-
-	resp.enrichFromCache(listener, m)
-
-	logger.Debug("fetched",
-		zap.Any("response", resp),
-	)
-
-	return resp, nil
 }
 
 func (listener *CarbonserverListener) fetchSingleMetricV2(metric string, fromTime, untilTime int32) (*protov2.FetchResponse, error) {

--- a/deploy/go-carbon.conf
+++ b/deploy/go-carbon.conf
@@ -238,6 +238,12 @@ scan-frequency = "5m0s"
 #  memory usage (by setting both trie-index and trigram-index to true).
 trie-index = false
 
+# This provides the ability to query for new metrics without any wsp files
+# i.e query for metrics present only in cache. Does a cache-scan and
+# populates index with metrics with or without corresponding wsp files.
+# Disabled by default.
+cache-scan = false
+
 # Maximum amount of globs in a single metric in index
 # This value is used to speed-up /find requests with
 # a lot of globs, but will lead to increased memory consumption

--- a/deploy/go-carbon.conf
+++ b/deploy/go-carbon.conf
@@ -240,8 +240,8 @@ trie-index = false
 
 # This provides the ability to query for new metrics without any wsp files
 # i.e query for metrics present only in cache. Does a cache-scan and
-# populates index with metrics with or without corresponding wsp files.
-# Disabled by default.
+# populates index with metrics with or without corresponding wsp files,
+# but will lead to increased memory consumption. Disabled by default.
 cache-scan = false
 
 # Maximum amount of globs in a single metric in index

--- a/persister/whisper.go
+++ b/persister/whisper.go
@@ -468,3 +468,23 @@ func (p *Whisper) Stop() {
 		p.maxCreatesTicker.Stop()
 	})
 }
+
+func (p *Whisper) GetRetentionPeriod(metric string) (int, bool){
+	schema, ok := p.schemas.Match(metric)
+	if !ok {
+		return 0,false
+	}
+
+	retentionStep := schema.Retentions[0].SecondsPerPoint()
+
+	return retentionStep,true
+}
+
+func (p *Whisper) GetAggrConf(metric string) (string, float64, bool){
+	aggr := p.aggregation.Match(metric)
+	if aggr == nil {
+			return "",float64(0),false
+	}
+
+	return aggr.Name(), aggr.XFilesFactor(), true
+}


### PR DESCRIPTION
  This is related to #318 

With this implementation, the index gets updated with new metrics even if there is no whisper file created on disk. This significantly reduces the delay in making the new metrics available for queries.

This change provides a new config-parameter `cache-scan`. When enabled -
- the index (trie/trigram) is updated/populated with metrics, including the ones without wsp files on disk 
- carbonserver can execute and send responses for queries (in first retention rate) on cache-only metrics once the index is updated.
- it takes *at most* the file-scan-frequency duration for the new metrics to show up.