### PR TITLE
[carbonlink] Python 3 Pickle Compatible Metric Request Parser

### DIFF
--- a/cache/carbonlink.go
+++ b/cache/carbonlink.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"encoding/binary"
 	"fmt"
-	"io/ioutil"
 	"math"
 	"net"
 	"strings"
@@ -98,7 +97,7 @@ var badErr error = fmt.Errorf("Bad pickle message")
 
 // ParseCarbonlinkRequest from pickle encoded data
 func ParseCarbonlinkRequest(d []byte) (*CarbonlinkRequest, error) {
-	ioutil.WriteFile("/tmp/pickle_msg", d, 0644)
+
 	var unicodePklMetricBytes, unicodePklTypeBytes []byte
 
 	if (expectBytes(&d, []byte("\x80\x02}")) ||

--- a/cache/carbonlink.go
+++ b/cache/carbonlink.go
@@ -98,8 +98,10 @@ var badErr error = fmt.Errorf("Bad pickle message")
 // ParseCarbonlinkRequest from pickle encoded data
 func ParseCarbonlinkRequest(d []byte) (*CarbonlinkRequest, error) {
 
-	var unicodePklMetricBytes, unicodePklTypeBytes []byte
+	asciiPklMetricBytes := []byte("U\x06metric")
+	asciiPklTypeBytes := []byte("U\x04type")
 
+	var unicodePklMetricBytes, unicodePklTypeBytes []byte
 	if (expectBytes(&d, []byte("\x80\x02}")) ||
 		expectBytes(&d, []byte("\x80\x03}"))) && pickleMaybeMemo(&d) && expectBytes(&d, []byte("(")) {
 		// message is using pickle protocol 2 or 3.
@@ -119,7 +121,7 @@ func ParseCarbonlinkRequest(d []byte) (*CarbonlinkRequest, error) {
 	var Metric, Type string
 	var ok bool
 
-	if expectBytes(&d, []byte("U\x06metric")) || expectBytes(&d, unicodePklMetricBytes) {
+	if expectBytes(&d, asciiPklMetricBytes) || expectBytes(&d, unicodePklMetricBytes) {
 		if !pickleMaybeMemo(&d) {
 			return nil, badErr
 		}
@@ -127,8 +129,9 @@ func ParseCarbonlinkRequest(d []byte) (*CarbonlinkRequest, error) {
 			return nil, badErr
 		}
 
-		if !(pickleMaybeMemo(&d) && (expectBytes(&d, []byte("U\x04type")) ||
-			expectBytes(&d, unicodePklTypeBytes)) && pickleMaybeMemo(&d)) {
+		if !(pickleMaybeMemo(&d) &&
+			(expectBytes(&d, asciiPklTypeBytes) || expectBytes(&d, unicodePklTypeBytes)) &&
+			pickleMaybeMemo(&d)) {
 			return nil, badErr
 		}
 
@@ -139,9 +142,11 @@ func ParseCarbonlinkRequest(d []byte) (*CarbonlinkRequest, error) {
 		if !pickleMaybeMemo(&d) {
 			return nil, badErr
 		}
+
 		req.Metric = Metric
 		req.Type = Type
-	} else if expectBytes(&d, []byte("U\x04type")) || expectBytes(&d, unicodePklTypeBytes) {
+
+	} else if expectBytes(&d, asciiPklTypeBytes) || expectBytes(&d, unicodePklTypeBytes) {
 		if !pickleMaybeMemo(&d) {
 			return nil, badErr
 		}
@@ -150,8 +155,9 @@ func ParseCarbonlinkRequest(d []byte) (*CarbonlinkRequest, error) {
 			return nil, badErr
 		}
 
-		if !(pickleMaybeMemo(&d) && (expectBytes(&d, []byte("U\x06metric")) ||
-			expectBytes(&d, unicodePklMetricBytes)) && pickleMaybeMemo(&d)) {
+		if !(pickleMaybeMemo(&d) &&
+			(expectBytes(&d, asciiPklMetricBytes) || expectBytes(&d, unicodePklMetricBytes)) &&
+			pickleMaybeMemo(&d)) {
 			return nil, badErr
 		}
 
@@ -162,8 +168,10 @@ func ParseCarbonlinkRequest(d []byte) (*CarbonlinkRequest, error) {
 		if !pickleMaybeMemo(&d) {
 			return nil, badErr
 		}
+
 		req.Metric = Metric
 		req.Type = Type
+
 	} else {
 		return nil, badErr
 	}

--- a/cache/carbonlink.go
+++ b/cache/carbonlink.go
@@ -83,9 +83,9 @@ func expectBytes(b *[]byte, v []byte) bool {
 }
 
 func protocolFourOrFiveFirstBytes(b *[]byte) bool {
-	// Parse and drop first 12 bytes of Pickle that is using protocol 4 or 5
+	// Parse and drop first 12 bytes of Pickle protocol 4 or 5, 12th byte must be "}"
 	if (bytes.Index(*b, []byte("\x80\x04")) == 0 ||
-		bytes.Index(*b, []byte("\x80\x05")) == 0) && bytes.Index(*b, []byte("}")) == 11 {
+		bytes.Index(*b, []byte("\x80\x05")) == 0) && bytes.Index((*b)[11:12], []byte("}")) == 0 {
 		*b = (*b)[12:]
 		return true
 	} else {

--- a/cache/carbonlink_test.go
+++ b/cache/carbonlink_test.go
@@ -223,7 +223,6 @@ func TestCarbonlink(t *testing.T) {
 	assert.NoError(err)
 
 	// {'datapoints': [(1582950001, 5431.0)]}
-
 	assert.Equal("\x80\x02}U\ndatapoints]Jq\xe6Y^G@\xb57\x00\x00\x00\x00\x00\x86as.", string(data))
 	cleanup()
 
@@ -242,7 +241,6 @@ func TestCarbonlink(t *testing.T) {
 	assert.NoError(err)
 
 	// {'datapoints': [(1587356401, 3600.0)]}
-
 	assert.Equal("\x80\x02}U\ndatapoints]J\xf1\"\x9d^G@\xac \x00\x00\x00\x00\x00\x86as.", string(data))
 	cleanup()
 

--- a/cache/carbonlink_test.go
+++ b/cache/carbonlink_test.go
@@ -11,9 +11,18 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+// Python 2.x ASCII protocol 2 Pickles
 const sampleCacheQuery = "\x00\x00\x00Y\x80\x02}q\x01(U\x06metricq\x02U,carbon.agents.carbon_agent_server.cache.sizeq\x03U\x04typeq\x04U\x0bcache-queryq\x05u."
 const sampleCacheQuery2 = "\x00\x00\x00Y\x80\x02}q\x01(U\x04typeq\x04U\x0bcache-queryq\x05U\x06metricq\x02U,carbon.agents.carbon_agent_server.param.sizeq\x03u."
-const sampleCacheQuery3 = "\x00\x00\x00R\x80\x02}(U\x06metricX,\x00\x00\x00carbon.agents.carbon_agent_server.param.sizeU\x04typeU\x0bcache-queryu." // unicode metric
+const sampleCacheQuery3 = "\x00\x00\x00R\x80\x02}(U\x06metricX,\x00\x00\x00carbon.agents.carbon_agent_server.param.sizeU\x04typeU\x0bcache-queryu." // unicode metric string, but not whole pickle message
+
+// Full unicode pickle ( Python 3.0+ )
+const unicodeQueryPklProtocol2 = "\x00\x00\x00h\x80\x02}q\x00(X\x04\x00\x00\x00typeq\x01X\x0b\x00\x00\x00cache-queryq\x02X\x06\x00\x00\x00metricq\x03X/\x00\x00\x00carbon.agents.carbon_agent_server.cache.metricsq\x04u."
+
+// Pickles with  protocols >2 ( Python 3.0 + )
+const unicodeQueryPklProtocol3 = "\x00\x00\x00h\x80\x03}q\x00(X\x04\x00\x00\x00typeq\x01X\x0b\x00\x00\x00cache-queryq\x02X\x06\x00\x00\x00metricq\x03X/\x00\x00\x00carbon.agents.carbon_agent_server.cache.metricsq\x04u."
+const unicodeQueryPklProtocol4 = "\x00\x00\x00e\x80\x04\x95Z\x00\x00\x00\x00\x00\x00\x00}\x94(\x8c\x06metric\x94\x8c4operations.mining.minerals.carbon.graphite.weight.kg\x94\x8c\x04type\x94\x8c\x0bcache-query\x94u."
+const unicodeQueryPklProtocol5 = "\x00\x00\x00Y\x80\x05\x95Q\x00\x00\x00\x00\x00\x00\x00}\x94(\x8c\x04type\x94\x8c\x0bcache-query\x94\x8c\x06metric\x94\x8c+pogoda.goroda.dozhd.prodolzhitelnost.sekund\x94u."
 
 func TestCarbonlink(t *testing.T) {
 	assert := assert.New(t)
@@ -38,9 +47,37 @@ func TestCarbonlink(t *testing.T) {
 		1422795966,
 	)
 
+	msgUnicodePklProtocol2 := points.OnePoint(
+		"carbon.agents.carbon_agent_server.cache.metrics",
+		1234,
+		1582129201,
+	)
+
+	msgUnicodePklProtocol3 := points.OnePoint(
+		"carbon.agents.carbon_agent_server.cache.metrics",
+		5555,
+		1582215601,
+	)
+
+	msgUnicodePklProtocol4 := points.OnePoint(
+		"operations.mining.minerals.carbon.graphite.weight.kg",
+		5431,
+		1582950001,
+	)
+
+	msgUnicodePklProtocol5 := points.OnePoint(
+		"pogoda.goroda.dozhd.prodolzhitelnost.sekund",
+		3600,
+		1587356401,
+	)
+
 	cache.Add(msg1)
 	cache.Add(msg2)
 	cache.Add(msg3)
+	cache.Add(msgUnicodePklProtocol2)
+	cache.Add(msgUnicodePklProtocol3)
+	cache.Add(msgUnicodePklProtocol4)
+	cache.Add(msgUnicodePklProtocol5)
 
 	defer cache.Stop()
 
@@ -133,6 +170,80 @@ func TestCarbonlink(t *testing.T) {
 	assert.NoError(err)
 
 	assert.Equal("\x80\x02}U\ndatapoints]s.", string(data))
+	cleanup()
+
+	/* Unicode Python 3.0+ Pickle Protocol 2 Message */
+	conn, cleanup = NewClient()
+
+	_, err = conn.Write([]byte(unicodeQueryPklProtocol2))
+	assert.NoError(err)
+
+	err = binary.Read(conn, binary.BigEndian, &replyLength)
+	assert.NoError(err)
+
+	data = make([]byte, replyLength)
+
+	err = binary.Read(conn, binary.BigEndian, data)
+	assert.NoError(err)
+
+	// {'datapoints': [(1582129201, 1234.0), (1582215601, 5555.0)]}
+	assert.Equal("\x80\x02}U\ndatapoints](J1`M^G@\x93H\x00\x00\x00\x00\x00\x86J\xb1\xb1N^G@\xb5\xb3\x00\x00\x00\x00\x00\x86es.", string(data))
+	cleanup()
+
+	/* Pickle Protocol 3 Message */
+	conn, cleanup = NewClient()
+
+	_, err = conn.Write([]byte(unicodeQueryPklProtocol3))
+	assert.NoError(err)
+
+	err = binary.Read(conn, binary.BigEndian, &replyLength)
+	assert.NoError(err)
+
+	data = make([]byte, replyLength)
+
+	err = binary.Read(conn, binary.BigEndian, data)
+	assert.NoError(err)
+
+	// {'datapoints': [(1582129201, 1234.0), (1582215601, 5555.0)]}
+	assert.Equal("\x80\x02}U\ndatapoints](J1`M^G@\x93H\x00\x00\x00\x00\x00\x86J\xb1\xb1N^G@\xb5\xb3\x00\x00\x00\x00\x00\x86es.", string(data))
+	cleanup()
+
+	/* Pickle Protocol 4 Message */
+	conn, cleanup = NewClient()
+
+	_, err = conn.Write([]byte(unicodeQueryPklProtocol4))
+	assert.NoError(err)
+
+	err = binary.Read(conn, binary.BigEndian, &replyLength)
+	assert.NoError(err)
+
+	data = make([]byte, replyLength)
+
+	err = binary.Read(conn, binary.BigEndian, data)
+	assert.NoError(err)
+
+	// {'datapoints': [(1582950001, 5431.0)]}
+
+	assert.Equal("\x80\x02}U\ndatapoints]Jq\xe6Y^G@\xb57\x00\x00\x00\x00\x00\x86as.", string(data))
+	cleanup()
+
+	/* Pickle Protocol 5 Message */
+	conn, cleanup = NewClient()
+
+	_, err = conn.Write([]byte(unicodeQueryPklProtocol5))
+	assert.NoError(err)
+
+	err = binary.Read(conn, binary.BigEndian, &replyLength)
+	assert.NoError(err)
+
+	data = make([]byte, replyLength)
+
+	err = binary.Read(conn, binary.BigEndian, data)
+	assert.NoError(err)
+
+	// {'datapoints': [(1587356401, 3600.0)]}
+
+	assert.Equal("\x80\x02}U\ndatapoints]J\xf1\"\x9d^G@\xac \x00\x00\x00\x00\x00\x86as.", string(data))
 	cleanup()
 
 	/* WRONG MESSAGE TEST */


### PR DESCRIPTION
### Problem 
When [graphite-web](https://github.com/graphite-project/graphite-web) is installed on Python 3.0+ environments `graphite-web` will send pickle request to `carbonlink` using the highest pickle protocol [(link to code in graphite-web) ](https://github.com/graphite-project/graphite-web/blob/master/webapp/graphite/carbonlink.py#L147).  

In python 3.0 until 3.7 highest pickle protocol is `4`, while in python 3.8 highest is `5`. 

Since `go-carbon's` `carbonlink` was written for python 2.x, when highest protocol available was `2`, it is unable to parse `carbonlink` pickle messages coming from python `graphite-web`. Even if the protocol is set to `2` when using python 3.x  it won't be able to parse it due encoding change from ASCII in python 2.x to Unicode in python 3.x. 

***Steps  to recreate***
Run `go-carbon` normally, but run `graphite-web` in Python 3.0+ and request a metric that will utilize `carbonlink`. You will see protocol 4 message request coming *protocol 5 in Python 3.8+). Consequently `go-carbon` will WARN regarding `bad pickle message` error and wont serve metric from cache.

```
# go-carbon
WARN [carbonlink] request parse failed {"peer": "ip_address", "error": "Bad pickle message"} 
# Graphite web
ConnectionRefusedError: [Errno 111] Connection refused
```

### PR Fixes
This PR should allow `carbonlink` to handle pickle protocols from 2 up to 5 by expanding the `carbonlink` pickle message parser to Python <= 3.8 pickle messages. More on python pickle protocols can be found [here](https://docs.python.org/3/library/pickle.html#data-stream-format)

Note: Will make PR later in [graphite-web](https://github.com/graphite-project/graphite-web) to make pickle protocol configurable for `carbonlink` requests, so that if newer python version with higher pickle protocol comes out it will not break `carbonlink` communication (one can set desired protocol)  if `go-carbon` will not be able to parse it.