### PR TITLE
go-carbon expose both versions as expvars and when runnig with -version

### DIFF
--- a/go-carbon.go
+++ b/go-carbon.go
@@ -66,6 +66,7 @@ func main() {
 
 	if *printVersion {
 		fmt.Println(Version)
+		fmt.Println(BuildVersion)
 		return
 	}
 
@@ -170,6 +171,7 @@ func main() {
 	if cfg.Pprof.Enabled {
 		expvar.NewString("GoVersion").Set(runtime.Version())
 		expvar.NewString("BuildVersion").Set(BuildVersion)
+		expvar.NewString("Version").Set(Version)
 		expvar.Publish("Config", expvar.Func(func() interface{} { return cfg }))
 		expvar.Publish("GoroutineCount", expvar.Func(func() interface{} { return runtime.NumGoroutine() }))
 	}


### PR DESCRIPTION
I noticed that we have to versions: Version and BuildVersion.
When running `go-carbon -version`, only Version is printed.
When reading expvars, only BuildVersion is printed.
They can get out of sync and then it's very confusing what version are
we really running.

With this change, I'm displaying both, for example:
```
./go-carbon --version
0.14.0
v0.14.0-101-g7b66-dirty
```
and
```
curl localhost:7007/debug/vars | jq . | grep Version
...
  "BuildVersion": "v0.14.0-101-g7b66-dirty",
  "Version": "0.14.0",
```