### PR TITLE
fix packages.sh

### DIFF
--- a/packages.sh
+++ b/packages.sh
@@ -3,16 +3,16 @@
 cd `dirname $0`
 ROOT=$PWD
 
-docker run -ti --rm -v $ROOT:/root/go/src/github.com/go-graphite/go-carbon ubuntu:18.10 bash -c '
+docker run -ti --rm -v $ROOT:/root/go/src/github.com/go-graphite/go-carbon ubuntu:20.04 bash -c '
     cd /root/
-    export GO_VERSION=1.10.3
+    export GO_VERSION=1.14
     apt-get update
     apt-get install -y rpm ruby ruby-dev wget make git gcc
 
     wget https://dl.google.com/go/go${GO_VERSION}.linux-amd64.tar.gz
     tar -C /usr/local -xzf go${GO_VERSION}.linux-amd64.tar.gz
     ln -s /usr/local/go/bin/go /usr/local/bin/go
-    
+
     # newer fpm is broken https://github.com/jordansissel/fpm/issues/1612
     gem install rake
     gem install fpm:1.10.2


### PR DESCRIPTION
This script was failing with this error:
```
Err:4 http://archive.ubuntu.com/ubuntu cosmic Release
  404  Not Found [IP: 91.189.88.142 80]
```

This is because Ubuntu 18.10 is EOL.
Updated to use 20.04 that is latest LTS: https://wiki.ubuntu.com/Releases

Also updated go version to 1.14