### PR TITLE
Fix pubsub test.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,22 +20,7 @@ debug: $(SOURCES)
 	$(GO) build -ldflags=-compressdwarf=false -gcflags=all='-l -N' $(MODULE)
 
 run-test:
-	$(GO) $(COMMAND) $(MODULE)
-	$(GO) $(COMMAND) $(MODULE)/cache
-	$(GO) $(COMMAND) $(MODULE)/carbon
-	$(GO) $(COMMAND) $(MODULE)/carbonserver
-	$(GO) $(COMMAND) $(MODULE)/helper/carbonzipperpb
-	$(GO) $(COMMAND) $(MODULE)/helper
-	$(GO) $(COMMAND) $(MODULE)/helper/qa
-	$(GO) $(COMMAND) $(MODULE)/helper/stat
-	$(GO) $(COMMAND) $(MODULE)/persister
-	$(GO) $(COMMAND) $(MODULE)/points
-	$(GO) $(COMMAND) $(MODULE)/tags
-	$(GO) $(COMMAND) $(MODULE)/receiver
-	$(GO) $(COMMAND) $(MODULE)/receiver/tcp
-	$(GO) $(COMMAND) $(MODULE)/receiver/udp
-	$(GO) $(COMMAND) $(MODULE)/receiver/parse
-	$(GO) $(COMMAND) $(MODULE)/receiver/http
+	$(GO) $(COMMAND) ./...
 
 test:
 	make run-test COMMAND="test"

--- a/receiver/pubsub/pubsub.go
+++ b/receiver/pubsub/pubsub.go
@@ -135,7 +135,7 @@ func newPubSub(client *pubsub.Client, name string, options *Options, store func(
 				rcv.handleMessage(m)
 				m.Ack()
 			})
-			if err == context.Canceled {
+			if cctx.Err() == context.Canceled {
 				close(rcv.closed)
 				rcv.Stop()
 				break

--- a/receiver/pubsub/pubsub_test.go
+++ b/receiver/pubsub/pubsub_test.go
@@ -79,10 +79,12 @@ func Test_handleMessage(t *testing.T) {
 			},
 		},
 		{
-			Desc:     "linemode, invalid body",
-			Data:     "hello.world 42.15 1422698155\nmetric.nam",
-			Error:    true,
-			Expected: []*points.Points{},
+			Desc:  "linemode, invalid body",
+			Data:  "hello.world 42.15 1422698155\nmetric.nam",
+			Error: true,
+			Expected: []*points.Points{
+				points.OnePoint("hello.world", 42.15, 1422698155),
+			},
 		},
 		{
 			Desc: "pickle, invalid body",


### PR DESCRIPTION
Simplify `test` target in Makefile.

While working on switching to modules I noticed that we don't need to
specify each package as target in Makefile 'test'.

When trying to replace that target with ./..., it started hanging
because of pubsub tests. By fixing this test, we can replace target with ./... .

Pubsub tests had  two issues:
 * hanging because we were checking if a context was canceled on
the error returned from rcv.subscription.Receive instead of calling
Err() on the context.
 * invalid test data; probably parsing got improved over time and since the test was skipped we did not notice this.