### PR TITLE
[travis-ci] Add apt-get update and go mod vendor to sync gox installation in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+
 language: go
 
 go:
@@ -8,8 +9,10 @@ script:
 
 before_deploy:
 - lsb_release -a
+- sudo apt-get update
 - sudo apt-get install -y ruby ruby-dev rpm
 - go get github.com/mitchellh/gox
+- go mod vendor
 - gem install fpm -v 1.11.0
 - make gox-build
 - make fpm-deb


### PR DESCRIPTION
Update apt repository during `before_deploy` and sync go modules after installing `gox` during build
Should fix #358 , one of maintainers please check it Travis :) 