### PR TITLE
Avereha/trace version

### DIFF
--- a/carbon/app.go
+++ b/carbon/app.go
@@ -316,7 +316,7 @@ func (app *App) startPersister() {
 }
 
 // Start starts
-func (app *App) Start() (err error) {
+func (app *App) Start(version string) (err error) {
 	app.Lock()
 	defer app.Unlock()
 
@@ -475,7 +475,7 @@ func (app *App) Start() (err error) {
 			carbonserver.InitPrometheus(app.PromRegisterer)
 		}
 		if conf.Tracing.Enabled {
-			app.FlushTraces = carbonserver.InitTracing(conf.Tracing.JaegerEndpoint, conf.Tracing.Stdout, conf.Tracing.SendTimeout.Value())
+			app.FlushTraces = carbonserver.InitTracing(conf.Tracing.JaegerEndpoint, conf.Tracing.Stdout, version, conf.Tracing.SendTimeout.Value())
 		}
 
 		if err = carbonserver.Listen(conf.Carbonserver.Listen); err != nil {

--- a/carbon/app_stop_test.go
+++ b/carbon/app_stop_test.go
@@ -23,7 +23,7 @@ func TestStartStop(t *testing.T) {
 			app := New(configFile)
 
 			assert.NoError(app.ParseConfig())
-			assert.NoError(app.Start())
+			assert.NoError(app.Start("test-version"))
 
 			app.Stop()
 		})
@@ -51,7 +51,7 @@ func TestReloadAndCollectorDeadlock(t *testing.T) {
 		assert.NoError(t, app.ParseConfig())
 
 		app.Config.Common.MetricInterval = &Duration{time.Microsecond}
-		assert.NoError(t, app.Start())
+		assert.NoError(t, app.Start("test-version"))
 
 		reloadChan := make(chan struct{}, 1)
 		N := 1024

--- a/carbonserver/trace.go
+++ b/carbonserver/trace.go
@@ -35,7 +35,7 @@ type headerName struct {
 }
 
 // initTracer creates a new trace provider instance and registers it as global trace provider.
-func (c *CarbonserverListener) InitTracing(jaegerEndpoint string, sendtoStdout bool, timeout time.Duration) func() {
+func (c *CarbonserverListener) InitTracing(jaegerEndpoint string, sendtoStdout bool,  version string, timeout time.Duration) func() {
 	logger := zapwriter.Logger("app")
 
 	propagator := trace.B3{}
@@ -64,6 +64,7 @@ func (c *CarbonserverListener) InitTracing(jaegerEndpoint string, sendtoStdout b
 				Tags: []kv.KeyValue{
 					kv.String("exporter", "jaeger"),
 					kv.String("host.hostname", fqdn),
+					kv.String("service.version", version),
 				},
 			}),
 			jaeger.RegisterAsGlobal(),

--- a/carbonserver/trace.go
+++ b/carbonserver/trace.go
@@ -35,7 +35,7 @@ type headerName struct {
 }
 
 // initTracer creates a new trace provider instance and registers it as global trace provider.
-func (c *CarbonserverListener) InitTracing(jaegerEndpoint string, sendtoStdout bool,  version string, timeout time.Duration) func() {
+func (c *CarbonserverListener) InitTracing(jaegerEndpoint string, sendtoStdout bool, version string, timeout time.Duration) func() {
 	logger := zapwriter.Logger("app")
 
 	propagator := trace.B3{}

--- a/go-carbon.go
+++ b/go-carbon.go
@@ -181,8 +181,7 @@ func main() {
 		app.PromRegisterer.MustRegister(prometheus.NewProcessCollector(prometheus.ProcessCollectorOpts{}))
 		http.Handle(cfg.Prometheus.Endpoint, promhttp.HandlerFor(app.PromRegistry, promhttp.HandlerOpts{}))
 	}
-	version := Version + "-"  + BuildVersion
-	if err = app.Start(version); err != nil {
+	if err = app.Start(BuildVersion); err != nil {
 		mainLogger.Fatal(err.Error())
 	} else {
 		mainLogger.Info("started")

--- a/go-carbon.go
+++ b/go-carbon.go
@@ -181,8 +181,8 @@ func main() {
 		app.PromRegisterer.MustRegister(prometheus.NewProcessCollector(prometheus.ProcessCollectorOpts{}))
 		http.Handle(cfg.Prometheus.Endpoint, promhttp.HandlerFor(app.PromRegistry, promhttp.HandlerOpts{}))
 	}
-
-	if err = app.Start(); err != nil {
+	version := Version + "-"  + BuildVersion
+	if err = app.Start(version); err != nil {
 		mainLogger.Fatal(err.Error())
 	} else {
 		mainLogger.Info("started")


### PR DESCRIPTION
Add `service.version` for all the traces.
That way, we can compare traces between two different go-carbon version as we are updating it.
I'm populating this field with `BuildVersion` because this variable contains `Version`