### PR TITLE
carbonserver: fix two panics related to prometheus #374

### DIFF
--- a/carbonserver/carbonserver.go
+++ b/carbonserver/carbonserver.go
@@ -358,6 +358,14 @@ func (c *CarbonserverListener) InitPrometheus(reg prom.Registerer) {
 		c.prometheus.diskRequests.Inc()
 	}
 
+	c.prometheus.cancelledRequest = func() {
+		c.prometheus.cancelledRequests.Inc()
+	}
+
+	c.prometheus.timeoutRequest = func() {
+		c.prometheus.timeoutRequests.Inc()
+	}
+
 	c.prometheus.diskWaitDuration = func(t time.Duration) {
 		c.prometheus.diskWaitDurations.Observe(t.Seconds())
 	}

--- a/carbonserver/find.go
+++ b/carbonserver/find.go
@@ -362,9 +362,9 @@ GATHER:
 		case <-ctx.Done():
 			switch ctx.Err() {
 			case context.DeadlineExceeded:
-				listener.prometheus.timeoutRequests.Inc()
+				listener.prometheus.timeoutRequest()
 			case context.Canceled:
-				listener.prometheus.cancelledRequests.Inc()
+				listener.prometheus.cancelledRequest()
 			}
 			return nil, fmt.Errorf("could not expand globs - %s", ctx.Err().Error())
 		}


### PR DESCRIPTION
It was introduced in commit 52fe9e23. Only triggered if prometheus
is not enabled.