### PR TITLE
Systemd improvements: start after network/fs online and allow more open files

### DIFF
--- a/deploy/go-carbon.service
+++ b/deploy/go-carbon.service
@@ -12,7 +12,7 @@ KillSignal=USR2
 Restart=on-failure
 
 TimeoutStopSec=600
-LimitNOFILE=55555
+LimitNOFILE=1048576
 LimitMEMLOCK=infinity
 
 [Install]

--- a/deploy/go-carbon.service
+++ b/deploy/go-carbon.service
@@ -1,7 +1,8 @@
 [Unit]
 Description=Golang implementation of Graphite/Carbon server.
 Documentation=https://github.com/go-graphite/go-carbon
-After=network.target
+After=network-online.target local-fs.target
+Wants=network-online.target local-fs.target
 
 [Service]
 Type=forking


### PR DESCRIPTION
This PR fixes an issue where go-carbon would start before the whisper data dir was mounted, leading to boot issues.
Also network-online.target is the correct thing to be After and Want.
Lastly, allow more open files to enable larger installations OOTB.