### PR TITLE
receiver/kafka: error handling fixes

### DIFF
--- a/receiver/kafka/kafka.go
+++ b/receiver/kafka/kafka.go
@@ -415,8 +415,8 @@ func (rcv *Kafka) consume() {
 }
 
 func (rcv *Kafka) connect() {
+	reconnectTimer := time.NewTicker(rcv.reconnectInterval)
 	for {
-		reconnectTimer := time.NewTicker(rcv.reconnectInterval)
 		select {
 		case <-rcv.closed:
 			close(rcv.workerClosed)

--- a/receiver/kafka/kafka.go
+++ b/receiver/kafka/kafka.go
@@ -373,8 +373,7 @@ func (rcv *Kafka) consume() {
 
 	partitionConsumer, err := consumer.ConsumePartition(rcv.connectOptions.topic, rcv.connectOptions.partition, rcv.kafkaState.Offset)
 	if err != nil {
-		switch err {
-		case sarama.ErrOffsetOutOfRange:
+		if err == sarama.ErrOffsetOutOfRange {
 			rcv.logger.Error(
 				"kafka state offset out of range, restart from the oldest offset",
 				zap.Int64("kafka_state_offset", rcv.kafkaState.Offset),

--- a/receiver/kafka/kafka.go
+++ b/receiver/kafka/kafka.go
@@ -330,6 +330,13 @@ func (rcv *Kafka) consume() {
 		)
 		return
 	}
+	defer func() {
+		if err := client.Close(); err != nil {
+			rcv.logger.Error("failed to close client",
+				zap.Error(err),
+			)
+		}
+	}()
 
 	if rcv.kafkaState.offsetIsTimestamp {
 		rcv.kafkaState.offsetIsTimestamp = false
@@ -356,15 +363,42 @@ func (rcv *Kafka) consume() {
 		)
 		return
 	}
+	defer func() {
+		if err := consumer.Close(); err != nil {
+			rcv.logger.Error("failed to close consumer",
+				zap.Error(err),
+			)
+		}
+	}()
 
 	partitionConsumer, err := consumer.ConsumePartition(rcv.connectOptions.topic, rcv.connectOptions.partition, rcv.kafkaState.Offset)
 	if err != nil {
-		rcv.logger.Error("failed to connect to kafka",
-			zap.Duration("reconnect_interval", rcv.reconnectInterval),
-			zap.Error(err),
-		)
-		return
+		switch err {
+		case sarama.ErrOffsetOutOfRange:
+			rcv.logger.Error(
+				"kafka state offset out of range, restart from the oldest offset",
+				zap.Int64("kafka_state_offset", rcv.kafkaState.Offset),
+			)
+			partitionConsumer, err = consumer.ConsumePartition(rcv.connectOptions.topic, rcv.connectOptions.partition, sarama.OffsetOldest)
+		}
+
+		if err != nil {
+			rcv.logger.Error("failed to consume from partition",
+				zap.String("topic", rcv.connectOptions.topic),
+				zap.Int32("partition", rcv.connectOptions.partition),
+				zap.Int64("offset", rcv.kafkaState.Offset),
+				zap.Error(err),
+			)
+			return
+		}
 	}
+	defer func() {
+		if err := partitionConsumer.Close(); err != nil {
+			rcv.logger.Error("failed to close partition consumer",
+				zap.Error(err),
+			)
+		}
+	}()
 	rcv.consumer = partitionConsumer
 
 	// Stop old worker
@@ -465,6 +499,8 @@ func (rcv *Kafka) worker() {
 			var payload []*points.Points
 			var err error
 			msgChan := rcv.consumer.Messages()
+			// TODO:
+			//  * handle reconnect (probably not necessary)?
 			for {
 				messageReceived := true
 				select {


### PR DESCRIPTION
Two changes for issue https://github.com/go-graphite/go-carbon/issues/412.

1. receiver/kafka: fix kafka connection leaks when it fails to consume partition

    Clients and consumers are not closed when consumer.ConsumePartition failed, which creates a resource leaks. If the error is sticky due to bad offset saved in state file, the receiver would keep creating new consumer connections and not closing them.

    This commit fixes the issue, by making sure the connections and consumers are closed if there is errors when trying to consume a partition.

    At the same time, if an sarama.ErrOffsetOutOfRange error is returned, it would just falls back to oldest offset, instead of keep retrying.

2. moves time.NewTicker out of for loop
