### PR TITLE
Bug fixes and small refactoring for carbonserver and trie index

### DIFF
--- a/README.md
+++ b/README.md
@@ -362,10 +362,10 @@ max-globs = 100
 fail-on-max-globs = false
 
 # Maximum metrics could be returned by glob/wildcard in find request (currently
-# works only for trie index)
+# works only for trie index) (Default: 10,000,000)
 max-metrics-globbed  = 30000
 # Maximum metrics could be returned in render request (works both all types of
-# indexes)
+# indexes) (Default: 1,000,000)
 max-metrics-rendered = 1000
 
 # graphite-web-10-mode

--- a/carbon/app.go
+++ b/carbon/app.go
@@ -465,6 +465,7 @@ func (app *App) Start(version string) (err error) {
 
 		var setConfigRetriever bool
 		if conf.Carbonserver.CacheScan {
+			core.InitCacheScanAdds()
 			carbonserver.SetCacheGetMetricsFunc(core.GetRecentNewMetrics)
 
 			setConfigRetriever = true

--- a/carbon/config.go
+++ b/carbon/config.go
@@ -227,8 +227,8 @@ func NewConfig() *Config {
 			FindCacheEnabled:   true,
 			TrigramIndex:       true,
 			CacheScan:          false,
-			MaxMetricsGlobbed:  30000,
-			MaxMetricsRendered: 1000,
+			MaxMetricsGlobbed:  10_000_000,
+			MaxMetricsRendered: 1_000_000,
 		},
 		Carbonlink: carbonlinkConfig{
 			Listen:  "127.0.0.1:7002",

--- a/carbonserver/cache_index_test.go
+++ b/carbonserver/cache_index_test.go
@@ -78,6 +78,7 @@ func getTestInfo(t *testing.T) *testInfo {
 	}
 
 	c := cache.New()
+	c.InitCacheScanAdds()
 	carbonserver := NewCarbonserverListener(c.Get)
 	carbonserver.whisperData = tmpDir
 	carbonserver.logger = zap.NewNop()

--- a/carbonserver/render.go
+++ b/carbonserver/render.go
@@ -371,6 +371,12 @@ func (listener *CarbonserverListener) prepareDataProto(ctx context.Context, logg
 			if expandedResult, ok := metricGlobMap[metric.Name]; ok {
 				files, leafs := expandedResult.Files, expandedResult.Leafs
 				if len(files) > listener.maxMetricsRendered {
+					listener.accessLogger.Error(
+						"rendering too many metrics",
+						zap.Int("limit", listener.maxMetricsRendered),
+						zap.Int("target", len(files)),
+					)
+
 					files = files[:listener.maxMetricsRendered]
 					leafs = leafs[:listener.maxMetricsRendered]
 				}

--- a/carbonserver/render.go
+++ b/carbonserver/render.go
@@ -387,7 +387,7 @@ func (listener *CarbonserverListener) prepareDataProto(ctx context.Context, logg
 						metricsCount++
 					}
 				}
-				listener.logger.Debug("expandGlobs result",
+				listener.accessLogger.Debug("expandGlobs result",
 					zap.String("handler", "render"),
 					zap.String("action", "expandGlobs"),
 					zap.String("metric", metric.Name),
@@ -400,7 +400,7 @@ func (listener *CarbonserverListener) prepareDataProto(ctx context.Context, logg
 					res, err := listener.fetchDataPB(metric.Name, files, leafs, fromTime, untilTime)
 					if err != nil {
 						atomic.AddUint64(&listener.metrics.RenderErrors, 1)
-						listener.logger.Error("error while fetching the data",
+						listener.accessLogger.Error("error while fetching the data",
 							zap.Error(err),
 						)
 						continue
@@ -410,7 +410,7 @@ func (listener *CarbonserverListener) prepareDataProto(ctx context.Context, logg
 					res, err := listener.fetchDataPB3(metric.Name, files, leafs, fromTime, untilTime)
 					if err != nil {
 						atomic.AddUint64(&listener.metrics.RenderErrors, 1)
-						listener.logger.Error("error while fetching the data",
+						listener.accessLogger.Error("error while fetching the data",
 							zap.Error(err),
 						)
 						continue
@@ -421,7 +421,7 @@ func (listener *CarbonserverListener) prepareDataProto(ctx context.Context, logg
 					multiv3.Metrics = append(multiv3.Metrics, res.Metrics...)
 				}
 			} else {
-				listener.logger.Debug("expand globs returned an error",
+				listener.accessLogger.Debug("expand globs returned an error",
 					zap.Error(err),
 				)
 				continue

--- a/deploy/go-carbon.conf
+++ b/deploy/go-carbon.conf
@@ -275,10 +275,10 @@ max-globs = 100
 fail-on-max-globs = false
 
 # Maximum metrics could be returned by glob/wildcard in find request (currently
-# works only for trie index)
+# works only for trie index) (Default: 10,000,000)
 max-metrics-globbed  = 30000
 # Maximum metrics could be returned in render request (works both all types of
-# indexes)
+# indexes) (Default: 1,000,000)
 max-metrics-rendered = 1000
 
 

--- a/go-carbon.conf.example
+++ b/go-carbon.conf.example
@@ -277,10 +277,10 @@ max-globs = 100
 fail-on-max-globs = false
 
 # Maximum metrics could be returned by glob/wildcard in find request (currently
-# works only for trie index)
+# works only for trie index) (Default: 10,000,000)
 max-metrics-globbed  = 30000
 # Maximum metrics could be returned in render request (works both all types of
-# indexes)
+# indexes) (Default: 1,000,000)
 max-metrics-rendered = 1000
 
 # graphite-web-10-mode


### PR DESCRIPTION
It's mainly a misc changes and bug fixes. 

Mostly backward-compatible changes except the default values of max-metrics-globbed and max-metrics-rendered.

1. cache-scan: only init Cache.Shard.adds when the feature is enabled

> cache-scan is a feature in go-cabron to enable quicker visibility of new metrics.
> However, if the feature is not enabled, no need to cache the new metrics info
> in Shard.adds map.

2. trie: numerious optimization and bug fixes for concurrent and realtime index

> * Fix incorrect index total_runtime calculation
> * Stop caching new metrics between file list scanning (which mean file list scanning interval should be slower than new metrics flushing to disk)
> * Start new file list scanning on startup right after loading files from cache: to avoid serving old file list cache too long
> * Move down the trie_count_nodes_time codes down to be within the indexing "block"
> * Add a new counter cache.droppedRealtimeIndex (use camelCase to stay consistent with the rest of cache.* metrics)
> * Re-initiating trieIndex when failed to load metrics from cache file
> * Some other minor changes here and there

3. carbonserver: change max-metrics-globbed and max-metrics-rendered defaults (for issue: https://github.com/go-graphite/go-carbon/issues/414)

> The default values might be too low for some of the users and it is a default introduced mainly
> for trie index. This commit change the default to a much bigger value to avoid silently truncated
> query result.

4. carbonserver: change error/debug log destination to access.log for CarbonserverListener.prepareDataProto
