### PR TITLE
mod: upgrade to go 1.16 and drops SOURCES from Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,20 +4,17 @@ DESCRIPTION:="Golang implementation of Graphite/Carbon server"
 MODULE:=github.com/go-graphite/go-carbon
 
 GO ?= go
-export GOPATH := $(CURDIR)/_vendor
 TEMPDIR:=$(shell mktemp -d)
 VERSION:=$(shell sh -c 'grep "const Version" $(NAME).go  | cut -d\" -f2')
 BUILD ?= $(shell git describe --abbrev=4 --dirty --always --tags)
 
-SOURCES=$(shell find . -name "*.go")
-
 all: $(NAME)
 
-$(NAME): $(SOURCES)
-	$(GO) build --ldflags '-X main.BuildVersion=$(BUILD)' $(MODULE)
+$(NAME):
+	$(GO) build -mod vendor --ldflags '-X main.BuildVersion=$(BUILD)' $(MODULE)
 
-debug: $(SOURCES)
-	$(GO) build -ldflags=-compressdwarf=false -gcflags=all='-l -N' $(MODULE)
+debug:
+	$(GO) build -mod vendor -ldflags=-compressdwarf=false -gcflags=all='-l -N' $(MODULE)
 
 run-test:
 	$(GO) $(COMMAND) ./...

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-graphite/go-carbon
 
-go 1.14
+go 1.16
 
 require (
 	cloud.google.com/go/pubsub v1.2.0


### PR DESCRIPTION
* The SOURCES list slows down make file due to listing 20k go files when upgrade to 1.16.
  Does not seem a necessary when using go build.
* Specify build -mod=vedor.
* Upgrade go version to 1.16.