### PR TITLE
ctrie: a bug fix for trigram statNodes

### DIFF
--- a/carbonserver/trie.go
+++ b/carbonserver/trie.go
@@ -875,6 +875,7 @@ func (ti *trieIndex) statNodes() map[*trieNode]int {
 
 		trieNodes[ncindex] = cur
 		cur = cur.getChild(curChildrens, nindex[ncindex])
+		curChildrens = cur.getChildrens()
 		ncindex++
 		if ncindex >= len(nindex)-1 {
 			goto parent


### PR DESCRIPTION
It was bug introduced with concurrent trie. The problem are only triggered if using
trie and trigram at the same time.