### PR TITLE
Introduces a quota subsystem

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Usage of go-carbon:
   -version=false: Print version
 ```
 
-```toml
+```ini
 [common]
 # Run as user. Works only in daemon mode
 user = "carbon"
@@ -101,6 +101,9 @@ data-dir = "/var/lib/graphite/whisper"
 schemas-file = "/etc/go-carbon/storage-schemas.conf"
 # http://graphite.readthedocs.org/en/latest/config-carbon.html#storage-aggregation-conf. Optional
 aggregation-file = "/etc/go-carbon/storage-aggregation.conf"
+# It's currently go-carbon only feature, not a standard graphite feature. Optional
+# More details in doc/quotas.md
+# quotas-file = "/etc/go-carbon/storage-quotas.conf"
 # Worker threads count. Metrics sharded by "crc32(metricName) % workers"
 workers = 8
 # Limits the number of whisper update_many() calls per second. 0 - no limit
@@ -327,6 +330,9 @@ scan-frequency = "5m0s"
 #  could be speeded up by enabling adding trigrams to trie, at the some costs of
 #  memory usage (by setting both trie-index and trigram-index to true).
 trie-index = false
+# Control how frequent it is to generate quota and usage metrics, and reset
+# throughput counters (More details in doc/quotas.md).
+# quota-usage-report-frequency = "1m"
 
 # Cache file list scan data in the specified path. This option speeds
 # up index building after reboot by reading the last scan result in file

--- a/cache/cache.go
+++ b/cache/cache.go
@@ -59,6 +59,8 @@ type Cache struct {
 	}
 
 	newMetricsChan chan string
+
+	throttle func(*points.Points) bool
 }
 
 // A "thread" safe string to anything map.
@@ -266,6 +268,10 @@ func (c *Cache) Add(p *points.Points) {
 		return
 	}
 
+	if c.throttle != nil && c.throttle(p) {
+		return
+	}
+
 	if s.tagsEnabled {
 		var err error
 		p.Metric, err = tags.Normalize(p.Metric)
@@ -367,3 +373,5 @@ func (c *Cache) GetRecentNewMetrics() []map[string]struct{} {
 	}
 	return metricNames
 }
+
+func (c *Cache) SetThrottle(throttle func(*points.Points) bool) { c.throttle = throttle }

--- a/cache/cache.go
+++ b/cache/cache.go
@@ -139,7 +139,7 @@ func (c *Cache) SetTagsEnabled(value bool) {
 
 func (c *Cache) SetNewMetricsChan(ch chan string) { c.newMetricsChan = ch }
 
-func (c *Cache) Stop() {}
+func (*Cache) Stop() {}
 
 // Collect cache metrics
 func (c *Cache) Stat(send helper.StatCallback) {

--- a/carbon/collector.go
+++ b/carbon/collector.go
@@ -133,7 +133,6 @@ func NewCollector(app *App) *Collector {
 				}
 			})
 		})
-
 	}
 
 	sendCallback := func(moduleName string) func(metric string, value float64) {

--- a/carbonserver/carbonserver.go
+++ b/carbonserver/carbonserver.go
@@ -91,6 +91,8 @@ type metricStruct struct {
 	TrieNodes            uint64
 	TrieFiles            uint64
 	TrieDirs             uint64
+	QuotaApplyTimeNs     uint64
+	UsageRefreshTimeNs   uint64
 }
 
 type requestsTimes struct {
@@ -250,6 +252,11 @@ type CarbonserverListener struct {
 	prometheus prometheus
 
 	db *leveldb.DB
+
+	quotas                    []*Quota
+	estimateSize              func(metric string) (size, dataPoints int64)
+	quotaAndUsageMetrics      atomic.Value // []points.Points
+	quotaUsageReportFrequency time.Duration
 }
 
 type prometheus struct {
@@ -475,6 +482,9 @@ func (listener *CarbonserverListener) SetBuckets(buckets int) {
 func (listener *CarbonserverListener) SetScanFrequency(scanFrequency time.Duration) {
 	listener.scanFrequency = scanFrequency
 }
+func (listener *CarbonserverListener) SetQuotaUsageReportFrequency(quotaUsageReportFrequency time.Duration) {
+	listener.quotaUsageReportFrequency = quotaUsageReportFrequency
+}
 func (listener *CarbonserverListener) SetReadTimeout(readTimeout time.Duration) {
 	listener.readTimeout = readTimeout
 }
@@ -530,6 +540,25 @@ func (listener *CarbonserverListener) SetInternalStatsDir(dbPath string) {
 }
 func (listener *CarbonserverListener) SetPercentiles(percentiles []int) {
 	listener.percentiles = percentiles
+}
+func (listener *CarbonserverListener) SetEstimateSize(f func(metric string) (size, dataPoints int64)) {
+	listener.estimateSize = f
+}
+func (listener *CarbonserverListener) SetQuotas(quotas []*Quota) {
+	listener.quotas = quotas
+}
+func (listener *CarbonserverListener) ShouldThrottleMetric(ps *points.Points) bool {
+	fidx := listener.CurrentFileIndex()
+	if fidx == nil || fidx.trieIdx == nil {
+		return false
+	}
+
+	var throttled = fidx.trieIdx.throttle(ps)
+	if strings.HasPrefix(ps.Metric, "vm.xhu.test.metrics") {
+		listener.logger.Info("metrics throttled\n", zap.String("metric", ps.Metric), zap.Bool("throttled", throttled))
+	}
+
+	return throttled
 }
 func (listener *CarbonserverListener) CurrentFileIndex() *fileIndex {
 	p := listener.fileIdx.Load()
@@ -613,23 +642,44 @@ func splitAndInsert(cacheMetricNames map[string]struct{}, newCacheMetricNames []
 
 func (listener *CarbonserverListener) fileListUpdater(dir string, tick <-chan time.Time, force <-chan struct{}, exit <-chan struct{}) {
 	cacheMetricNames := make(map[string]struct{})
+	qaurtFreq := listener.quotaUsageReportFrequency
+	if qaurtFreq <= 0 {
+		qaurtFreq = time.Minute
+	}
+	qaurt := time.NewTicker(qaurtFreq) // quota and usage refresh ticker
 
 uloop:
 	for {
 		select {
 		case <-exit:
+			qaurt.Stop()
 			return
 		case <-tick:
 		case <-force:
+		case <-qaurt.C:
+			listener.refreshQuotaAndUsage()
+
+			// drain remaining blocked tickers
+		quartDrainLoop:
+			for {
+				select {
+				case <-qaurt.C:
+				default:
+					break quartDrainLoop
+				}
+			}
+
+			continue uloop
 		case m := <-listener.newMetricsChan:
 			fidx := listener.CurrentFileIndex()
 			if listener.trieIndex && listener.concurrentIndex && fidx != nil && fidx.trieIdx != nil {
 				metric := "/" + filepath.Clean(strings.ReplaceAll(m, ".", "/")+".wsp")
 
-				if err := fidx.trieIdx.insert(metric); err != nil {
+				if err := fidx.trieIdx.insert(metric, 0, 0, 0); err != nil {
 					listener.logTrieInsertError(listener.logger, "failed to insert new metrics for realtime indexing", metric, err)
 				}
 			}
+
 			continue uloop
 		}
 
@@ -644,7 +694,36 @@ uloop:
 			listener.logger.Info("file list updated with cache, starting a new scan immediately")
 			listener.updateFileList(dir, cacheMetricNames)
 		}
+
+		listener.refreshQuotaAndUsage()
 	}
+}
+
+func (listener *CarbonserverListener) refreshQuotaAndUsage() {
+	fidx := listener.CurrentFileIndex()
+
+	if len(listener.quotas) == 0 || !listener.concurrentIndex || listener.realtimeIndex <= 0 || fidx == nil || fidx.trieIdx == nil {
+		return
+	}
+
+	quotaStart := time.Now()
+	fidx.trieIdx.applyQuotas(listener.quotas...)
+	quotaTime := uint64(time.Since(quotaStart))
+	atomic.StoreUint64(&listener.metrics.QuotaApplyTimeNs, quotaTime)
+
+	usageStart := time.Now()
+	fidx.trieIdx.refreshUsage()
+	usageTime := uint64(time.Since(usageStart))
+	atomic.StoreUint64(&listener.metrics.UsageRefreshTimeNs, usageTime)
+
+	listener.quotaAndUsageMetrics.Store(fidx.trieIdx.qauMetrics)
+	fidx.trieIdx.qauMetrics = nil
+
+	listener.logger.Debug(
+		"refreshQuotaAndUsage",
+		zap.Uint64("quota_apply_time", quotaTime),
+		zap.Uint64("usage_refresh_time", usageTime),
+	)
 }
 
 func (listener *CarbonserverListener) updateFileList(dir string, cacheMetricNames map[string]struct{}) (readFromCache bool) {
@@ -668,7 +747,7 @@ func (listener *CarbonserverListener) updateFileList(dir string, cacheMetricName
 	var infos []zap.Field
 	if listener.trieIndex {
 		if fidx == nil || !listener.concurrentIndex {
-			trieIdx = newTrie(".wsp")
+			trieIdx = newTrie(".wsp", listener.estimateSize)
 		} else {
 			trieIdx = fidx.trieIdx
 			trieIdx.root.gen++
@@ -681,7 +760,7 @@ func (listener *CarbonserverListener) updateFileList(dir string, cacheMetricName
 	var cacheMetricLen = len(cacheMetricNames)
 	for fileName := range cacheMetricNames {
 		if listener.trieIndex {
-			if err := trieIdx.insert(fileName); err != nil {
+			if err := trieIdx.insert(fileName, 0, 0, 0); err != nil {
 				listener.logTrieInsertError(logger, "error populating index from cache indexMap", fileName, err)
 			}
 		} else {
@@ -707,11 +786,11 @@ func (listener *CarbonserverListener) updateFileList(dir string, cacheMetricName
 				if entry == "" {
 					continue
 				}
-				if err := trieIdx.insert(entry); err != nil {
+				if err := trieIdx.insert(entry, 0, 0, 0); err != nil {
 					listener.logTrieInsertError(logger, "failed to read from file list cache", entry, err)
 					readFromCache = false
 
-					trieIdx = newTrie(".wsp")
+					trieIdx = newTrie(".wsp", listener.estimateSize)
 					break
 				}
 				filesLen++
@@ -745,24 +824,48 @@ func (listener *CarbonserverListener) updateFileList(dir string, cacheMetricName
 				}()
 			}
 		}
+
 		if fi, err := os.Lstat(dir); err != nil {
 			logger.Error("failed to stat whisper data directory", zap.String("path", dir), zap.Error(err))
 		} else if fi.Mode()&os.ModeSymlink == 1 {
 			logger.Error("can't index symlink data dir", zap.String("path", dir))
 		}
+
+		var usageRefreshTimeout = struct {
+			refreshedAt time.Time
+			count       int
+		}{time.Now(), 0}
 		err := filepath.Walk(dir, func(p string, info os.FileInfo, err error) error {
 			if err != nil {
 				logger.Info("error processing", zap.String("path", p), zap.Error(err))
 				return nil
 			}
 
-			//  && len(listener.newMetricsChan) >= cap(listener.newMetricsChan)/2
+			// WHY: as filepath.walk could potentially taking a long
+			// time to complete (>= 5 minutes or more), depending
+			// on how many files are there on disk. It's nice to
+			// have consistent quota and usage metrics produced as
+			// regularly as possible according to the
+			// quotaUsageReportFrequency specified in the config.
+			if usageRefreshTimeout.count++; usageRefreshTimeout.count > 10_000 && time.Since(usageRefreshTimeout.refreshedAt) >= listener.quotaUsageReportFrequency {
+				listener.refreshQuotaAndUsage()
+				usageRefreshTimeout.refreshedAt = time.Now()
+			}
+
+			// WHY: as filepath.walk could potentially taking a long
+			// time to complete (>= 5 minutes or more), depending
+			// on how many files are there on disk. It's nice to
+			// try to flush newMetricsChan if possible.
+			//
+			// TODO: only trigger enter the loop when it's half full?
+			// 	len(listener.newMetricsChan) >= cap(listener.newMetricsChan)/2
 			if listener.trieIndex && listener.concurrentIndex && listener.newMetricsChan != nil {
 			newMetricsLoop:
 				for {
 					select {
 					case m := <-listener.newMetricsChan:
-						if err := trieIdx.insert(filepath.Clean(strings.ReplaceAll(m, ".", "/") + ".wsp")); err != nil {
+						fileName := "/" + filepath.Clean(strings.ReplaceAll(m, ".", "/")+".wsp")
+						if err := trieIdx.insert(fileName, 0, 0, 0); err != nil {
 							listener.logTrieInsertError(logger, "failed to update realtime trie index", m, err)
 						}
 					default:
@@ -791,7 +894,19 @@ func (listener *CarbonserverListener) updateFileList(dir string, cacheMetricName
 					delete(cacheMetricNames, trimmedName)
 				} else {
 					if listener.trieIndex {
-						if err := trieIdx.insert(trimmedName); err != nil {
+						var dataPoints int64
+						if isFullMetric && listener.estimateSize != nil {
+							m := strings.ReplaceAll(trimmedName, "/", ".")
+							m = m[1 : len(m)-4]
+							_, dataPoints = listener.estimateSize(m)
+						}
+
+						var physicalSize = info.Size()
+						if stat, ok := info.Sys().(*syscall.Stat_t); ok {
+							physicalSize = stat.Blocks * 512
+						}
+
+						if err := trieIdx.insert(trimmedName, info.Size(), physicalSize, dataPoints); err != nil {
 							// It's better to just log an error than stop indexing
 							listener.logTrieInsertError(logger, "updateFileList.trie: failed to index path", trimmedName, err)
 						}
@@ -1188,6 +1303,10 @@ func (listener *CarbonserverListener) Stat(send helper.StatCallback) {
 		senderRaw("trie_index_files", &listener.metrics.TrieFiles, send)
 		senderRaw("trie_index_dirs", &listener.metrics.TrieDirs, send)
 	}
+	if len(listener.quotas) > 0 {
+		senderRaw("quota_apply_time_ns", &listener.metrics.QuotaApplyTimeNs, send)
+		senderRaw("usage_refresh_time_ns", &listener.metrics.UsageRefreshTimeNs, send)
+	}
 
 	sender("alloc", &alloc, send)
 	sender("total_alloc", &totalAlloc, send)
@@ -1224,6 +1343,12 @@ func (listener *CarbonserverListener) Stat(send helper.StatCallback) {
 				send(fmt.Sprintf("request_time_%vth_percentile_ns", p), float64(list[key]))
 			}
 		}
+	}
+
+	// why using _: avoid panics due to casting nil atomic.Value
+	qauMetrics, _ := listener.quotaAndUsageMetrics.Load().([]points.Points)
+	for _, ps := range qauMetrics {
+		send(ps.Metric, float64(ps.Data[0].Value))
 	}
 }
 
@@ -1348,6 +1473,18 @@ func (listener *CarbonserverListener) Listen(listen string) error {
 		case <-time.After(time.Second):
 			w.WriteHeader(http.StatusServiceUnavailable)
 		}
+	})
+
+	carbonserverMux.HandleFunc("/admin/quota", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Add("Content-Type", "text/plain")
+
+		fidx := listener.CurrentFileIndex()
+		if fidx == nil && fidx.trieIdx == nil {
+			fmt.Fprintf(w, "index doesn't exist.")
+			return
+		}
+
+		fidx.trieIdx.getQuotaTree(w)
 	})
 
 	carbonserverMux.HandleFunc("/robots.txt", func(w http.ResponseWriter, r *http.Request) {

--- a/carbonserver/carbonserver.go
+++ b/carbonserver/carbonserver.go
@@ -562,6 +562,8 @@ func (listener *CarbonserverListener) ShouldThrottleMetric(ps *points.Points, in
 
 	return throttled
 }
+
+// skipcq: RVV-B0011
 func (listener *CarbonserverListener) CurrentFileIndex() *fileIndex {
 	p := listener.fileIdx.Load()
 	if p == nil {
@@ -572,6 +574,7 @@ func (listener *CarbonserverListener) CurrentFileIndex() *fileIndex {
 
 func (listener *CarbonserverListener) UpdateFileIndex(fidx *fileIndex) { listener.fileIdx.Store(fidx) }
 
+// skipcq: RVV-A0005
 func (listener *CarbonserverListener) UpdateMetricsAccessTimes(metrics map[string]int64, initial bool) {
 	idx := listener.CurrentFileIndex()
 	if idx == nil {

--- a/carbonserver/trie.go
+++ b/carbonserver/trie.go
@@ -403,6 +403,7 @@ func (dm *dirMeta) withinQuota(metrics, namespaces, logical, physical, dataPoint
 
 var emptyTrieNodes = &[]*trieNode{}
 
+// TODO: consider not initialize fileMeta if quota feature isn't enabled?
 func newFileNode(m uint8, logicalSize, physicalSize, dataPoints int64) *trieNode {
 	return &trieNode{
 		childrens: emptyTrieNodes,
@@ -1505,7 +1506,7 @@ func (ti *trieIndex) applyQuotas(quotas ...*Quota) error {
 
 // refreshUsage updates usage data and generate stat metrics.
 // It can't be evoked with concurrent trieIndex.insert.
-func (ti *trieIndex) refreshUsage() {
+func (ti *trieIndex) refreshUsage() (files uint64) {
 	type state struct {
 		next      int
 		node      *trieNode
@@ -1594,6 +1595,8 @@ func (ti *trieIndex) refreshUsage() {
 			cur.physicalSize += cur.node.meta.(*fileMeta).physicalSize
 			cur.dataPoints += cur.node.meta.(*fileMeta).dataPoints
 
+			files++
+
 			goto parent
 		} else if cur.node.dir() {
 			dirs[dirIndex]++
@@ -1624,6 +1627,8 @@ func (ti *trieIndex) refreshUsage() {
 
 		continue
 	}
+
+	return
 }
 
 func (ti *trieIndex) generateQuotaAndUsageMetrics(prefix, name string, node *trieNode) {

--- a/carbonserver/trie.go
+++ b/carbonserver/trie.go
@@ -1800,10 +1800,12 @@ func (ti *trieIndex) getNodeFullPath(node *trieNode) string {
 
 func (ti *trieIndex) throttle(ps *points.Points) bool {
 	var node = ti.root
-	var dirs = []*trieNode{ti.root}
+	var dirs = make([]*trieNode, 0, 32) // WHY: reduce the majority of allocations in mloop
 	var mindex int
 	var isNew bool
 	var metric = ps.Metric
+
+	dirs = append(dirs, ti.root)
 
 mloop:
 	for {

--- a/carbonserver/trie.go
+++ b/carbonserver/trie.go
@@ -930,6 +930,7 @@ func (ti *trieIndex) allMetrics(sep byte) []string {
 	return files
 }
 
+// skipcq: SCC-U1000
 func (ti *trieIndex) dump(w io.Writer) {
 	var depth = ti.getDepth() + trieDepthBuffer
 	var nindex = make([]int, depth)

--- a/carbonserver/trie_real_test.go
+++ b/carbonserver/trie_real_test.go
@@ -235,9 +235,9 @@ func uniqFilesLeafs(files []string, leafs []bool) ([]string, []bool) {
 
 func TestTrieContinuousUpdate(t *testing.T) {
 	files := readFile(*testDataPath)
-	ptrie := newTrie(".wsp")
+	ptrie := newTrie(".wsp", nil, )
 	for i := 0; i < 100; i++ {
-		ttrie := newTrie(".wsp")
+		ttrie := newTrie(".wsp", nil, )
 		ptrie.root.gen++
 		var count int
 		fmt.Println("--- run", i, count)
@@ -246,8 +246,8 @@ func TestTrieContinuousUpdate(t *testing.T) {
 				continue
 			}
 			count++
-			ptrie.insert(f)
-			ttrie.insert(f)
+			ptrie.insert(f, 0, 0, 0)
+			ttrie.insert(f, 0, 0, 0)
 		}
 
 		count0, files0, dirs0, onec0, onefc0, onedc0, countByChildren0, nodesByMark0 := ptrie.countNodes()

--- a/carbonserver/trie_test.go
+++ b/carbonserver/trie_test.go
@@ -26,6 +26,7 @@ type logf interface {
 	Logf(format string, args ...interface{})
 }
 
+// skipcq: RVV-A0005
 func newTrieServer(files []string, withTrigram bool, l logf) *CarbonserverListener {
 	var listener CarbonserverListener
 	listener.logger = zap.NewNop()
@@ -781,6 +782,7 @@ func TestTrieConcurrentReadWrite(t *testing.T) {
 			return
 		// case <-filec:
 		default:
+			// skipcq: GSC-G404
 			files, _, _, err := trieIndex.query(fmt.Sprintf("level-0-%d/level-1-%d/level-2-%d*", rand.Intn(factor), rand.Intn(factor), rand.Intn(factor)), int(math.MaxInt64), nil)
 			if err != nil {
 				panic(err)
@@ -1176,6 +1178,7 @@ func TestTrieQuotaGeneral(t *testing.T) {
 		},
 		{
 			input1: (func() (r []metric) {
+				// skipcq: CRT-P0001
 				r = append(r, metric{"/sys/app/srv1/nodes/host-01/cpu.wsp", 1, 1, 1})
 				r = append(r, metric{"/sys/app/srv1/nodes/host-01/mem.wsp", 1, 1, 1})
 				r = append(r, metric{"/sys/app/srv2/nodes/host-01/mem.wsp", 1, 1, 1})

--- a/carbonserver/trie_test.go
+++ b/carbonserver/trie_test.go
@@ -737,7 +737,7 @@ func TestTrieEdgeCases(t *testing.T) {
 		t.Errorf("trie should return an range overflow error")
 	}
 
-	if err := trie.insert("ns1/ns2/ns3/ns4/ns5/ns7/"); err != nil {
+	if err := trie.insert("ns1/ns2/ns3/ns4/ns5/ns7/", 0, 0, 0); err != nil {
 		t.Errorf("should not return insert error when inserting folders")
 	}
 }

--- a/deploy/go-carbon.conf
+++ b/deploy/go-carbon.conf
@@ -39,6 +39,9 @@ hash-filenames = true
 compressed = false
 # automatically delete empty whisper file caused by edge cases like server reboot
 remove-empty-file = false
+# It's currently go-carbon only feature, not a standard graphite feature. Optional
+# More details in doc/quotas.md
+# quotas-file = "/etc/go-carbon/storage-quotas.conf"
 
 [cache]
 # Limit of in-memory stored points (not metrics)
@@ -240,6 +243,9 @@ scan-frequency = "5m0s"
 #  could be speeded up by enabling adding trigrams to trie, at the some costs of
 #  memory usage (by setting both trie-index and trigram-index to true).
 trie-index = false
+# Control how frequent it is to generate quota and usage metrics, and reset
+# throughput counters (More details in doc/quotas.md).
+# quota-usage-report-frequency = "1m"
 
 # Cache file list scan data in the specified path. This option speeds
 # up index building after reboot by reading the last scan result in file

--- a/deploy/storage-quota.conf
+++ b/deploy/storage-quota.conf
@@ -1,0 +1,24 @@
+
+# This control all the namespaces under root
+[*]
+metrics       =       1,000,000
+logical-size  = 250,000,000,000
+physical-size =  50,000,000,000
+# max means practically no limit
+data-points   =             max
+throughput    =             max
+
+[sys.app.*]
+metrics       =         3,000,000
+logical-size  = 1,500,000,000,000
+physical-size =   100,000,000,000
+data-points   =   130,000,000,000
+
+# This controls the root/global limits
+[/]
+namespaces    =                20
+metrics       =        10,000,000
+logical-size  = 2,500,000,000,000
+physical-size = 2,500,000,000,000
+data-points   =   200,000,000,000
+dropping-policy = new

--- a/doc/quotas.md
+++ b/doc/quotas.md
@@ -1,0 +1,110 @@
+# Quotas
+
+In large Graphite (go-carbon) storage installations, it's desirable to have control over how many resources a user can consume.
+
+Go-Carbon addresses this issue by the implementation of pattern-matching based quota design.
+
+Limitations/Caveats:
+
+* The current implementation is based on concurrent/realtime trie-index, so to use quotas, also need to enable those features on go-carbon.
+* Pattern matching rules aren't regexp, but like graphite query syntax, using globs.
+* Quota and usage metrics are only produced if the the control has non-empty quota values.
+
+## Available controls
+
+* namespaces: how many sub-namespaces are allowed for the matched prefix/namespaces
+* metrics: how many metrics are allowed for the matched prefix/namespaces
+* logical-size: how many logical disk space are allowed for the matched prefix/namespaces
+* physical-size: how many physical disk space are allowed for the matched prefix/namespaces
+* data-points: how many data points (inferred using storage-schemas.conf) are allowed for the matched prefix/namespaces
+* throughput: how many data points are allowed within the interval specified by `carbonserver.quota-usage-report-frequency` for the matched prefix/namespaces
+* dropping-policy: available values includes `none` and `new`. `none` means doesn't not drop any values. `new` means dropping new metrics. `none` can be used to produce only the quota, usage, and throttle metrics without actually dropping the data.
+
+### Why `logical-size` and `physical-size`
+
+If `whisper.sparse-create` or `whisper.compressed` is enabled, logical size could be much larger than physical size.
+
+Distinguishing them gives us control for that scenario.
+
+### `data-points` and `logical-size`
+
+Usually, `data_points` corresponds to `logical-size` as they are both determined by its matching retention policy.
+
+### `throughput`
+
+Throughput controls how many data points are allowed within the interval specified by `carbonserver.quota-usage-report-frequency`.
+
+This is useful for us to monitor how many datapoints are sent to a specific patthen/namespace. It's useful for cases like some of those namespaces are generating too many datapoints and causing other namespaces to be overflown in the memory cache.
+
+The value is reset every interval specified by `carbonserver.quota-usage-report-frequency`.
+
+If `carbonserver.quota-usage-report-frequency` is 1 minute, then `throughput = 600,000`, then it means only 600k data points per minute are allowed to be pushed to the matched namespace/pattern.
+
+For `throughput` control, both new and old metrics might be dropped, depending their arriving order.
+
+## Special values
+
+The control values can be set to `max`/`maximum`, which is set to max int64 (9,223,372,036,854,775,807), and it practically means no limit.
+
+If the config is not set or set to empty ``, then no quota and usage metrics will be produced.
+
+## Stat Metrics
+
+When using quota, go-carbon will also generate usage, quota, and throttling metrics for each matched patterns.
+
+```
+carbon.agents.{host}.quota.metrics.sys
+carbon.agents.{host}.usage.metrics.app
+carbon.agents.{host}.throttle.app
+...
+```
+
+The `carbon.agents.{host}` is from config `common.graph-prefix`.
+
+We can also define a prefix for the generated path, using `stat-metric-prefix` for each matched patterns.
+
+## How to enable Quotas
+
+For go-carbon.conf:
+
+```ini
+[whisper]
+quotas-file = "/etc/go-carbon/storage-quotas.conf"
+
+[carbonserver]
+scan-frequency = "2h"
+trie-index = true
+concurrent-index = true
+realtime-index = 65536
+quota-usage-report-frequency = "1m"
+```
+
+Quota config example:
+
+```ini
+# This control all the namespaces under root
+[*]
+metrics       =       3,000,000
+logical-size  = 250,000,000,000
+physical-size =  25,000,000,000
+# max means practically no limit
+data-points   =             max
+throughput    =             max
+stat-metric-prefix = "level1."
+
+[sys.app.*]
+metrics       =         3,000,000
+logical-size  = 1,500,000,000,000
+physical-size =   250,000,000,000
+data-points   =   130,000,000,000
+stat-metric-prefix = "level2."
+
+# This controls the root/global limits
+[/]
+namespaces    =                20
+metrics       =        10,000,000
+logical-size  = 2,500,000,000,000
+physical-size = 2,500,000,000,000
+data-points   =   200,000,000,000
+dropping-policy = new
+```

--- a/persister/whisper.go
+++ b/persister/whisper.go
@@ -54,6 +54,7 @@ type Whisper struct {
 	mockStore               func() (StoreFunc, func())
 	logger                  *zap.Logger
 	createLogger            *zap.Logger
+
 	// blockThrottleNs        uint64 // sum ns counter
 	// blockQueueGetNs        uint64 // sum ns counter
 	// blockAvoidConcurrentNs uint64 // sum ns counter
@@ -321,6 +322,9 @@ func (p *Whisper) store(metric string) {
 
 	// start = time.Now()
 	p.updateMany(w, path, points)
+
+	// TODO: produce realtime size info and forward it to carbonserver.trieIndex
+	// fi := w.File().Stat()
 
 	w.Close()
 	// atomic.AddUint64(&p.blockUpdateManyNs, uint64(time.Since(start).Nanoseconds()))

--- a/persister/whisper.go
+++ b/persister/whisper.go
@@ -496,7 +496,7 @@ func (p *Whisper) GetAggrConf(metric string) (string, float64, bool) {
 // simplifyPathError retruns an error without path in the error message. This
 // simpplies the log a bit as the path is usually printed separately and the
 // new error message is easier to filter in elastic search and other tools.
-func (p *Whisper) simplifyPathError(err error) error {
+func (*Whisper) simplifyPathError(err error) error {
 	perr, ok := err.(*os.PathError)
 	if !ok {
 		return err

--- a/persister/whisper_quota.go
+++ b/persister/whisper_quota.go
@@ -1,0 +1,87 @@
+package persister
+
+import (
+	"fmt"
+	"math"
+	"strconv"
+	"strings"
+)
+
+// Quota represents one quota setting.
+type Quota struct {
+	Pattern          string
+	Namespaces       int64
+	Metrics          int64
+	LogicalSize      int64
+	PhysicalSize     int64
+	DataPoints       int64
+	Throughput       int64
+	DroppingPolicy   string
+	StatMetricPrefix string
+}
+
+type WhisperQuotas []Quota
+
+// ReadWhisperQuotas reads and parses a storage-quotas.conf file and returns the
+// defined quotas.
+func ReadWhisperQuotas(filename string) (WhisperQuotas, error) {
+	config, err := parseIniFile(filename)
+	if err != nil {
+		return nil, err
+	}
+
+	var quotas WhisperQuotas
+
+	parseInt := func(section map[string]string, name string) (int64, error) {
+		str := section[name]
+		switch str {
+		case "":
+			return 0, nil
+		case "maximum", "max":
+			return math.MaxInt64, nil
+		}
+
+		v, err := strconv.ParseInt(strings.ReplaceAll(str, ",", ""), 10, 64)
+		if err != nil {
+			err = fmt.Errorf("[persister] Failed to parse %s for [%s]: %s", name, section["name"], err)
+		}
+		return v, err
+	}
+
+	for _, section := range config {
+		var quota Quota
+		quota.Pattern = section["name"]
+
+		if quota.Namespaces, err = parseInt(section, "namespaces"); err != nil {
+			return nil, err
+		}
+		if quota.Metrics, err = parseInt(section, "metrics"); err != nil {
+			return nil, err
+		}
+		if quota.LogicalSize, err = parseInt(section, "logical-size"); err != nil {
+			return nil, err
+		}
+		if quota.PhysicalSize, err = parseInt(section, "physical-size"); err != nil {
+			return nil, err
+		}
+		if quota.DataPoints, err = parseInt(section, "data-points"); err != nil {
+			return nil, err
+		}
+		if quota.Throughput, err = parseInt(section, "throughput"); err != nil {
+			return nil, err
+		}
+
+		switch v := section["dropping-policy"]; v {
+		case "new", "none", "":
+			quota.DroppingPolicy = v
+		default:
+			return nil, fmt.Errorf("[persister] Unknown dropping-policy %q for [%s]", v, section["name"])
+		}
+
+		quota.StatMetricPrefix = strings.TrimPrefix(section["stat-metric-prefix"], ".")
+
+		quotas = append(quotas, quota)
+	}
+
+	return quotas, nil
+}

--- a/points/points.go
+++ b/points/points.go
@@ -197,3 +197,10 @@ func (p *Points) Eq(other *Points) bool {
 	}
 	return true
 }
+
+// TODO: for realtime metric size update (from persister to carbonserver)
+type MetaMetric struct {
+	Path         string
+	PhysicalSize int
+	LogicalSize  int
+}


### PR DESCRIPTION
The quota subsystem is made to improve control, reliability and visibility of go-carbon.
It is not a standard graphite component, but it is backward compatible and
could be turned on optionally.

Caveat: the current implementation only supports concurrent/realtime trie index.

The quota subsystem allows user to control how many resources can be consumed
on a patter-matching based basis.

Implemented controls include: data points (based retention policy), disk size
(logical and physical), throughput, metric count, and namespaces (i.e. immediate
sub-directory count).

**More details could be found in [doc/quotas.md](https://github.com/go-graphite/go-carbon/blob/quota/doc/quotas.md) in the PR.**

An example configuration:

```ini
# This control all the namespaces under root
[*]
metrics       =       1,000,000
logical_size  = 250,000,000,000
physical_size =  50,000,000,000
# max means practically no limit
data_points   =             max
throughput    =             max

[sys.app.*]
metrics       =         3,000,000
logical_size  = 1,500,000,000,000
physical_size =   100,000,000,000
data_points   =   130,000,000,000

# This controls the root/global limits
[/]
namespaces    =                20
metrics       =        10,000,000
logical_size  = 2,500,000,000,000
physical_size = 2,500,000,000,000
data_points   =   200,000,000,000
dropping_policy = new
```

Throttling control is implemented in `carbonserver`, while quota config 
is implemented in persister (mainly for convenience).