### PR TITLE
carbonserver: log more detailed errors about symlink and continue trie index despite error

### DIFF
--- a/carbon/app.go
+++ b/carbon/app.go
@@ -437,6 +437,14 @@ func (app *App) Start(version string) (err error) {
 			return
 		}
 
+		if conf.Carbonserver.TrigramIndex || conf.Carbonserver.TrieIndex {
+			if fi, err := os.Lstat(conf.Whisper.DataDir); err != nil {
+				return fmt.Errorf("failed to stat whisper data directory: %s", err)
+			} else if fi.Mode()&os.ModeSymlink == 1 {
+				return fmt.Errorf("whisper data directory is a symlink")
+			}
+		}
+
 		carbonserver := carbonserver.NewCarbonserverListener(core.Get)
 		carbonserver.SetWhisperData(conf.Whisper.DataDir)
 		carbonserver.SetMaxGlobs(conf.Carbonserver.MaxGlobs)

--- a/carbonserver/trie.go
+++ b/carbonserver/trie.go
@@ -542,10 +542,22 @@ outer:
 	// TODO: there seems to be a problem of fetching a directory node without files
 
 	if !isFile {
-		// TODO: should double check if / already exists
 		if cur.dir() {
+			return nil
+		}
+
+		var newDir = true
+		for _, child := range *cur.childrens {
+			if child.dir() {
+				cur = child
+				newDir = false
+				break
+			}
+		}
+		if newDir {
 			cur.addChild(&trieNode{c: []byte{'/'}, childrens: &[]*trieNode{}, gen: ti.root.gen})
 		}
+
 		return nil
 	}
 

--- a/carbonserver/trie.go
+++ b/carbonserver/trie.go
@@ -378,6 +378,13 @@ type nilFilenameError string
 
 func (nfe nilFilenameError) Error() string { return string(nfe) }
 
+type trieInsertError struct {
+	typ  string
+	info string
+}
+
+func (t *trieInsertError) Error() string { return t.typ }
+
 // TODO: add some defensive logics agains bad paths?
 //
 // abc.def.ghi
@@ -399,7 +406,7 @@ func (ti *trieIndex) insert(path string) error {
 	}
 
 	if path == "" || path[len(path)-1] == '/' {
-		return nilFilenameError(fmt.Sprintf("metric fileename is nil: %s", path))
+		return nilFilenameError("metric filename is nil")
 	}
 
 	if uint64(len(path)) > ti.getDepth() {
@@ -474,7 +481,7 @@ outer:
 					goto dir
 				}
 
-				return fmt.Errorf("failed to index metric %s: unknwon case of match == nlen = %d", path, nlen)
+				return &trieInsertError{typ: "failed to index metric: unknwon case of match == nlen", info: fmt.Sprintf("match == nlen == %d", nlen)}
 			}
 
 			if match == len(child.c) && len(child.c) < nlen { // case 2

--- a/carbonserver/trie_test.go
+++ b/carbonserver/trie_test.go
@@ -670,6 +670,19 @@ func TestTrieIndex(t *testing.T) {
 			},
 			expectLeafs: []bool{true, false},
 		},
+		{
+			input: []string{
+				"/ns1/ns2/ns3/ns4/ns5/ns6/ns7_handle.wsp",
+				"/ns1/ns2/ns3/ns4/ns5/ns6_1/",
+				"/ns1/ns2/ns3/ns4/ns5/ns6_2",
+			},
+			query: "ns1.ns2.ns3.ns4.ns5.*",
+			expect: []string{
+				".", // should we even support . as filename?
+				"ns1",
+			},
+			expectLeafs: []bool{true, false},
+		},
 	}
 
 	for _, c := range cases {
@@ -711,6 +724,10 @@ func TestTrieEdgeCases(t *testing.T) {
 	_, _, err := trie.query("[\xff\xff-\xff", 1000, func([]string) ([]string, error) { return nil, nil })
 	if err == nil || err.Error() != "glob: range overflow" {
 		t.Errorf("trie should return an range overflow error")
+	}
+
+	if err := trie.insert("ns1/ns2/ns3/ns4/ns5/ns7/"); err != nil {
+		t.Errorf("should not return insert error when inserting folders")
 	}
 }
 

--- a/carbonserver/trie_test.go
+++ b/carbonserver/trie_test.go
@@ -675,13 +675,20 @@ func TestTrieIndex(t *testing.T) {
 				"/ns1/ns2/ns3/ns4/ns5/ns6/ns7_handle.wsp",
 				"/ns1/ns2/ns3/ns4/ns5/ns6_1/",
 				"/ns1/ns2/ns3/ns4/ns5/ns6_2",
+				"/ns1/ns2/ns3/ns4/ns5/ns6_3/",
+				"/ns1/ns2/ns3/ns4/ns5/ns6_3/",
+				"/ns1/ns2/ns3/ns4/ns5/ns6_3/",
+				"/ns1/ns2/ns3/ns4/ns5/ns6_3/",
+				"/ns1/ns2/ns3/ns4/ns5/ns6_3/metric.wsp",
 			},
 			query: "ns1.ns2.ns3.ns4.ns5.*",
 			expect: []string{
-				".", // should we even support . as filename?
-				"ns1",
+				"ns1.ns2.ns3.ns4.ns5.ns6",
+				"ns1.ns2.ns3.ns4.ns5.ns6_1",
+				"ns1.ns2.ns3.ns4.ns5.ns6_2",
+				"ns1.ns2.ns3.ns4.ns5.ns6_3",
 			},
-			expectLeafs: []bool{true, false},
+			expectLeafs: []bool{false, false, false, false},
 		},
 	}
 
@@ -708,6 +715,8 @@ func TestTrieIndex(t *testing.T) {
 					trieFiles[i] += fmt.Sprintf(" %t", result.Leafs[i])
 				}
 			}
+
+			// trieServer.CurrentFileIndex().trieIdx.dump(os.Stdout)
 
 			sort.Strings(trieFiles)
 			sort.Strings(c.expect)


### PR DESCRIPTION
Two issues are resolved in this commit:

* filepath.Walk does not follow symlinks, so it is good practice to log errors during startup
  and indexing when whisper data dir is a symlink.
* trie.insert could return errors if broken filename or paths or bugs are encountered or
  triggered. originally it would stop indexing when error is returned for a specific metric
  path, but it is better to continue indexing and just log the error.