### PR TITLE
carbonserver: adds /admin/info endpoint for returning internal info

### DIFF
--- a/cache/cache.go
+++ b/cache/cache.go
@@ -378,3 +378,15 @@ func (c *Cache) GetRecentNewMetrics() []map[string]struct{} {
 func (c *Cache) SetThrottle(throttle func(ps *points.Points, inCache bool) bool) {
 	c.throttle = throttle
 }
+
+func (c *Cache) GetInfo() map[string]interface{} {
+	s, ok := c.settings.Load().(*cacheSettings)
+	if !ok {
+		return map[string]interface{}{}
+	}
+
+	return map[string]interface{}{
+		"size":  c.stat.size,
+		"limit": s.maxSize,
+	}
+}

--- a/carbon/app.go
+++ b/carbon/app.go
@@ -537,6 +537,8 @@ func (app *App) Start(version string) (err error) {
 			return
 		}
 
+		carbonserver.RegisterInternalInfoHandler("cache", core.GetInfo)
+
 		app.Carbonserver = carbonserver
 	}
 	/* CARBONSERVER end */


### PR DESCRIPTION
currently only cache info are returned. it could be used by other programs like buckytool
to check if the operations are hurting go-carbon and causing disruptions of the
service.

this is mostly an early setup. more stat and info could be added and returned in the future.