### PR TITLE
persister: online schema migration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@
 * Introducing `persiter.oooDiscardedPoints` metric #463
 * Fixing OOO discard metric overflow #464
 * refactoring `persiter.oooDiscardedPoints` metric #TBD
+* __Online Schema/Aggregation Migration__ #438
+* tool/persister_configs_differ and -check-policies flag in go-carbon #438
+
 ##### version 0.16.2
 * Another attempt to fix issues with release upload #449
 

--- a/README.md
+++ b/README.md
@@ -145,10 +145,6 @@ compressed = false
 # automatically delete empty whisper file caused by edge cases like server reboot
 remove-empty-file = false
 
-# It's currently go-carbon only feature, not a standard graphite feature. Optional
-# More details in doc/quotas.md
-# quotas-file = "/etc/go-carbon/storage-quotas.conf"
-
 # Enable online whisper file config migration.
 #
 # online-migration-rate means metrics per second to migrate.

--- a/README.md
+++ b/README.md
@@ -145,6 +145,28 @@ compressed = false
 # automatically delete empty whisper file caused by edge cases like server reboot
 remove-empty-file = false
 
+# It's currently go-carbon only feature, not a standard graphite feature. Optional
+# More details in doc/quotas.md
+# quotas-file = "/etc/go-carbon/storage-quotas.conf"
+
+# Enable online whisper file config migration.
+#
+# online-migration-rate means metrics per second to migrate.
+#
+# To partially enable default migration for only some matched rules in
+# storage-schemas.conf or storage-aggregation.conf, we can set
+# online-migration-global-scope = "-" and enable the migration in those config
+# files.
+#
+# online-migration-global-scope can also be set any combination of the 3 rules
+# (xff,aggregationMethod,schema) as a csv string
+# like: "xff", "xff,aggregationMethod", "xff,schema",
+# or "xff,aggregationMethod,schema".
+#
+# online-migration = false
+# online-migration-rate = 5
+# online-migration-global-scope = "-"
+
 [cache]
 # Limit of in-memory stored points (not metrics)
 max-size = 1000000

--- a/carbon/app.go
+++ b/carbon/app.go
@@ -318,8 +318,12 @@ func (app *App) startPersister() {
 			p.SetTaggedFn(app.Tags.Add)
 		}
 
-		p.Start()
+		if cfg := app.Config.Whisper; cfg.OnlineMigration {
+			scope := strings.Split(strings.TrimSpace(cfg.OnlineMigrationGlobalScope), ",")
+			p.EnableOnlineMigration(cfg.OnlineMigrationRate, scope)
+		}
 
+		p.Start()
 		app.Persister = p
 	}
 }

--- a/carbon/app.go
+++ b/carbon/app.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
+	"log"
 	"net"
 	"net/url"
 	"os"
@@ -609,5 +610,19 @@ func (app *App) Loop() {
 
 	if exitChan != nil {
 		<-app.exit
+	}
+}
+
+func (app *App) CheckPersisterPolicyConsistencies(rate int, printInconsistentMetrics bool) {
+	p := persister.NewWhisper(
+		app.Config.Whisper.DataDir,
+		app.Config.Whisper.Schemas,
+		app.Config.Whisper.Aggregation,
+		nil, nil, nil, nil,
+	)
+	err := p.CheckPolicyConsistencies(rate, printInconsistentMetrics)
+	if err != nil {
+		log.Printf("failed to check policy consistencies: %s\n", err)
+		return
 	}
 }

--- a/carbon/config.go
+++ b/carbon/config.go
@@ -71,6 +71,10 @@ type whisperConfig struct {
 	Aggregation             *persister.WhisperAggregation
 	Quotas                  persister.WhisperQuotas
 	RemoveEmptyFile         bool `toml:"remove-empty-file"`
+
+	OnlineMigration            bool   `toml:"online-migration"`
+	OnlineMigrationRate        int    `toml:"online-migration-rate"` // metrics per second
+	OnlineMigrationGlobalScope string `toml:"online-migration-global-scope"`
 }
 
 type cacheConfig struct {
@@ -204,6 +208,10 @@ func NewConfig() *Config {
 			Sparse:              false,
 			FLock:               false,
 			HashFilenames:       true,
+
+			OnlineMigration:            false,
+			OnlineMigrationRate:        5,
+			OnlineMigrationGlobalScope: "",
 		},
 		Cache: cacheConfig{
 			MaxSize:       1000000,

--- a/carbonserver/fetchfromdisk.go
+++ b/carbonserver/fetchfromdisk.go
@@ -70,7 +70,7 @@ func (listener *CarbonserverListener) fetchFromDisk(metric string, fromTime, unt
 
 	res := &metricFromDisk{
 		Metadata: Metadata{
-			ConsolidationFunc: w.AggregationMethod(),
+			ConsolidationFunc: strings.Title(w.AggregationMethod().String()),
 			XFilesFactor:      w.XFilesFactor(),
 		},
 	}

--- a/carbonserver/fetchfromdisk.go
+++ b/carbonserver/fetchfromdisk.go
@@ -7,10 +7,9 @@ import (
 	"sync/atomic"
 	"time"
 
-	"go.uber.org/zap"
-
 	"github.com/go-graphite/go-carbon/points"
 	"github.com/go-graphite/go-whisper"
+	"go.uber.org/zap"
 )
 
 type Metadata struct {
@@ -70,7 +69,7 @@ func (listener *CarbonserverListener) fetchFromDisk(metric string, fromTime, unt
 
 	res := &metricFromDisk{
 		Metadata: Metadata{
-			ConsolidationFunc: strings.Title(w.AggregationMethod().String()),
+			ConsolidationFunc: titleizeAggrMethod(w.AggregationMethod().String()),
 			XFilesFactor:      w.XFilesFactor(),
 		},
 	}

--- a/carbonserver/info.go
+++ b/carbonserver/info.go
@@ -101,7 +101,7 @@ func (listener *CarbonserverListener) infoHandler(wr http.ResponseWriter, req *h
 
 		defer w.Close()
 
-		aggr := w.AggregationMethod()
+		aggr := strings.Title(w.AggregationMethod().String())
 		maxr := int64(w.MaxRetention())
 		xfiles := float32(w.XFilesFactor())
 

--- a/carbonserver/info.go
+++ b/carbonserver/info.go
@@ -101,7 +101,7 @@ func (listener *CarbonserverListener) infoHandler(wr http.ResponseWriter, req *h
 
 		defer w.Close()
 
-		aggr := strings.Title(w.AggregationMethod().String())
+		aggr := titleizeAggrMethod(w.AggregationMethod().String())
 		maxr := int64(w.MaxRetention())
 		xfiles := float32(w.XFilesFactor())
 
@@ -189,4 +189,10 @@ func (listener *CarbonserverListener) infoHandler(wr http.ResponseWriter, req *h
 		zap.Duration("runtime_seconds", time.Since(t0)),
 		zap.Int("http_code", http.StatusOK),
 	)
+}
+
+// strings.Title is deprecated and for go-carbon, it's only for simple use case.
+// no unicode support is needed.
+func titleizeAggrMethod(aggr string) string {
+	return strings.ToUpper(aggr[:1]) + aggr[1:]
 }

--- a/deploy/storage-aggregation.conf
+++ b/deploy/storage-aggregation.conf
@@ -5,3 +5,9 @@
 pattern = .*
 xFilesFactor = 0.5
 aggregationMethod = average
+
+# Partialy enable or disable online config migration for the matched metrics, only
+# works if whisper.online-migration is enabled
+#
+# xffMigration = false
+# aggregationMethodMigration = false

--- a/deploy/storage-aggregation.conf
+++ b/deploy/storage-aggregation.conf
@@ -6,8 +6,9 @@ pattern = .*
 xFilesFactor = 0.5
 aggregationMethod = average
 
-# Partialy enable or disable online config migration for the matched metrics, only
-# works if whisper.online-migration is enabled
+# Partialy enable or disable online config migration for the matched metrics;
+# only works if whisper.online-migration is enabled (more in
+# deploy/go-carbon.conf and README.md).
 #
 # xffMigration = false
 # aggregationMethodMigration = false

--- a/deploy/storage-schemas.conf
+++ b/deploy/storage-schemas.conf
@@ -7,3 +7,8 @@
 pattern = .*
 retentions = 60s:30d,1h:5y
 compressed = false
+
+# Partialy enable or disable online config migration for the matched metrics, only
+# works if whisper.online-migration is enabled
+#
+# migration = false

--- a/deploy/storage-schemas.conf
+++ b/deploy/storage-schemas.conf
@@ -8,7 +8,8 @@ pattern = .*
 retentions = 60s:30d,1h:5y
 compressed = false
 
-# Partialy enable or disable online config migration for the matched metrics, only
-# works if whisper.online-migration is enabled
+# Partialy enable or disable online config migration for the matched metrics;
+# only works if whisper.online-migration is enabled (more in
+# deploy/go-carbon.conf and README.md).
 #
 # migration = false

--- a/go-carbon.conf.example
+++ b/go-carbon.conf.example
@@ -16,6 +16,9 @@ data-dir = "/var/lib/graphite/whisper"
 schemas-file = "/etc/go-carbon/storage-schemas.conf"
 # http://graphite.readthedocs.org/en/latest/config-carbon.html#storage-aggregation-conf. Optional
 aggregation-file = "/etc/go-carbon/storage-aggregation.conf"
+# It's currently go-carbon only feature, not a standard graphite feature. Optional
+# More details in doc/quotas.md
+# quotas-file = "/etc/go-carbon/storage-quotas.conf"
 # Worker threads count. Metrics sharded by "crc32(metricName) % workers"
 workers = 8
 # Limits the number of whisper update_many() calls per second. 0 - no limit
@@ -39,6 +42,24 @@ hash-filenames = true
 compressed = false
 # automatically delete empty whisper file caused by edge cases like server reboot
 remove-empty-file = false
+
+# Enable online whisper file config migration.
+#
+# online-migration-rate means metrics per second to migrate.
+#
+# To partially enable default migration for only some matched rules in
+# storage-schemas.conf or storage-aggregation.conf, we can set
+# online-migration-global-scope = "-" and enable the migration in the config
+# files (more examples in deploy/storage-aggregation.conf and deploy/storage-schemas.conf).
+#
+# online-migration-global-scope can also be set any combination of the 3 rules
+# (xff,aggregationMethod,schema) as a csv string
+# like: "xff", "xff,aggregationMethod", "xff,schema",
+# or "xff,aggregationMethod,schema".
+#
+# online-migration = false
+# online-migration-rate = 5
+# online-migration-global-scope = "-"
 
 [cache]
 # Limit of in-memory stored points (not metrics)
@@ -242,6 +263,9 @@ scan-frequency = "5m0s"
 #  could be speeded up by enabling adding trigrams to trie, at the some costs of
 #  memory usage (by setting both trie-index and trigram-index to true).
 trie-index = false
+# Control how frequent it is to generate quota and usage metrics, and reset
+# throughput counters (More details in doc/quotas.md).
+# quota-usage-report-frequency = "1m"
 
 # Cache file list scan data in the specified path. This option speeds
 # up index building after reboot by reading the last scan result in file
@@ -262,6 +286,29 @@ concurrent-index = false
 # Currently only trie-index is supported. 
 # (EXPERIMENTAL)
 realtime-index = 0
+
+# Maximum inflight requests allowed in go-carbon. Default is 0 which means no limit.
+# If limit is reached, go-carbon/carbonserver returns 429 (Too Many Requests).
+# This option would be handy as if there are too many long running requests piling up,
+# it would slows down data ingestion in persister and slows down index building
+# (especially during restart).
+max-inflight-requests = 0
+
+# Returns 503 (Service Unavailable) when go-carbon is still building the first
+# index cache (trie/trigram) after restart. With trie or trigram index,
+# carbonserver falls back to filepath.Glob when index is not ready. And
+# filepath.Glob is expensive and not scaled enough to support some heavy
+# queries (manifested as high usage and frequent GC). Thus it is possible that
+# the read requests is so heavy that it not only slows down index building, it
+# also hinders persister from flushing down data to disk and causing cache.size
+# overflow.
+#
+# By default, it is disabled.
+#
+# It is recommend to enable this flag together with "file-list-cache" (depends on
+# the number of metrics, indexing building with "file-list-cache" is usually
+# much faster than re-scanning the whole file tree after restart).
+no-service-when-index-is-not-ready = false
 
 # This provides the ability to query for new metrics without any wsp files
 # i.e query for metrics present only in cache. Does a cache-scan and

--- a/go-carbon.go
+++ b/go-carbon.go
@@ -55,6 +55,10 @@ func main() {
 	printDefaultConfig := flag.Bool("config-print-default", false, "Print default config")
 	checkConfig := flag.Bool("check-config", false, "Check config and exit")
 
+	// Scan metrics to check if there are mismatches against schema and aggregation configs.
+	checkPolicies := flag.Int("check-policies", 0, "Scan all whisper files for inconsistencies of schema and aggregation policies. Triggered with a positive value. The positive value is used for specifying the check speed (unit: metrics per second).")
+	printInconsistentMetrics := flag.Bool("print-inconsistent-metrics", false, "Prints metric path with inconsistent configs, Used with -check-policies.")
+
 	printVersion := flag.Bool("version", false, "Print version")
 
 	isDaemon := flag.Bool("daemon", false, "Run in background")
@@ -107,6 +111,11 @@ func main() {
 
 	// config parsed successfully. Exit in check-only mode
 	if *checkConfig {
+		return
+	}
+
+	if *checkPolicies > 0 {
+		app.CheckPersisterPolicyConsistencies(*checkPolicies, *printInconsistentMetrics)
 		return
 	}
 

--- a/go-carbon.go
+++ b/go-carbon.go
@@ -56,7 +56,7 @@ func main() {
 	checkConfig := flag.Bool("check-config", false, "Check config and exit")
 
 	// Scan metrics to check if there are mismatches against schema and aggregation configs.
-	checkPolicies := flag.Int("check-policies", 0, "Scan all whisper files for inconsistencies of schema and aggregation policies. Triggered with a positive value. The positive value is used for specifying the check speed (unit: metrics per second).")
+	checkPolicies := flag.Int("check-policies", 0, "Scan all whisper files for inconsistencies of schema and aggregation policies. Triggered with a positive value. The positive value is used for specifying the check speed (unit: metrics per second). Example value: 120.")
 	printInconsistentMetrics := flag.Bool("print-inconsistent-metrics", false, "Prints metric path with inconsistent configs, Used with -check-policies.")
 
 	printVersion := flag.Bool("version", false, "Print version")

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/dgryski/go-trigram v0.0.0-20160407183937-79ec494e1ad0
 	github.com/dgryski/httputil v0.0.0-20160116060654-189c2918cd08
 	github.com/go-graphite/carbonzipper v0.0.0-20180329125635-fedce067a794
-	github.com/go-graphite/go-whisper v0.0.0-20220503135514-632dcc5beca8
+	github.com/go-graphite/go-whisper v0.0.0-20220504075317-5035f072cad3
 	github.com/go-graphite/protocol v0.4.3-0.20180731190405-5ae324d48067
 	github.com/gogo/protobuf v1.1.2-0.20180830160456-5669497fd644
 	github.com/google/go-cmp v0.5.0

--- a/go.sum
+++ b/go.sum
@@ -76,14 +76,8 @@ github.com/go-gl/glfw/v3.3/glfw v0.0.0-20191125211704-12ad95a8df72/go.mod h1:tQ2
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20200222043503-6f7a984d4dc4/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
 github.com/go-graphite/carbonzipper v0.0.0-20180329125635-fedce067a794 h1:9N+1I8z47huAZdcBWVIqfZZPzIzMyXqGd3uR21QN5mA=
 github.com/go-graphite/carbonzipper v0.0.0-20180329125635-fedce067a794/go.mod h1:sfZ+AkP8/bBcWSGVqhseV6t6e/+C0i/PkTpA32W5rXs=
-github.com/go-graphite/go-whisper v0.0.0-20220426133541-b1ea42367ab4 h1:ztjpW09cYf5/rrqcXTAR+gJBehzvNnmrjTJlgOvOKdM=
-github.com/go-graphite/go-whisper v0.0.0-20220426133541-b1ea42367ab4/go.mod h1:XnU8q9X8C3OhD8R7gAlRLI6VXU2KMwqgTO9Tshub2qE=
-github.com/go-graphite/go-whisper v0.0.0-20220429140939-695cec35c3a5 h1:XkbQS9Hl+rQrehwJuzT0b+eoDLMs+MIFOPn1V3J9YFE=
-github.com/go-graphite/go-whisper v0.0.0-20220429140939-695cec35c3a5/go.mod h1:XnU8q9X8C3OhD8R7gAlRLI6VXU2KMwqgTO9Tshub2qE=
-github.com/go-graphite/go-whisper v0.0.0-20220429144459-e27098c23e15 h1:QCrZGb7FZ6l949+nbymqNmQlmvqBwNJompNAOFP5IQ8=
-github.com/go-graphite/go-whisper v0.0.0-20220429144459-e27098c23e15/go.mod h1:XnU8q9X8C3OhD8R7gAlRLI6VXU2KMwqgTO9Tshub2qE=
-github.com/go-graphite/go-whisper v0.0.0-20220503135514-632dcc5beca8 h1:6XeNaa2qMDOpAx57nuJSfosoPlr3gskIZe47s58b1Fg=
-github.com/go-graphite/go-whisper v0.0.0-20220503135514-632dcc5beca8/go.mod h1:XnU8q9X8C3OhD8R7gAlRLI6VXU2KMwqgTO9Tshub2qE=
+github.com/go-graphite/go-whisper v0.0.0-20220504075317-5035f072cad3 h1:QlegEOONT3wkw4c8/dIwGeAahnHonvJ1MaUUzPviZxk=
+github.com/go-graphite/go-whisper v0.0.0-20220504075317-5035f072cad3/go.mod h1:XnU8q9X8C3OhD8R7gAlRLI6VXU2KMwqgTO9Tshub2qE=
 github.com/go-graphite/protocol v0.4.3-0.20180731190405-5ae324d48067 h1:3xaKhHeiu8sY1oFpgw8mou3IztFUB92FIGwDncZKJCs=
 github.com/go-graphite/protocol v0.4.3-0.20180731190405-5ae324d48067/go.mod h1:tJs3CWCesQ9Laqjz5pbMDHqJlPHDUZv502EtN7qujzQ=
 github.com/gogo/protobuf v1.1.2-0.20180830160456-5669497fd644 h1:GsuTRapGULopujrq87TLdlXsp6m3q/tOwxgx7EEwhKc=

--- a/persister/whisper.go
+++ b/persister/whisper.go
@@ -70,6 +70,7 @@ type Whisper struct {
 
 		stat struct {
 			total               uint32
+			errors              uint32
 			schema              uint32
 			xff                 uint32
 			aggregationMethod   uint32
@@ -366,7 +367,18 @@ func (p *Whisper) store(metric string) {
 	// Check if schema and aggregation is still up-to-date
 	if !newFile && p.onlineMigration.enabled {
 		// errors are logged already
-		w, _, _ = p.checkAndUpdateSchemaAndAggregation(w, metric)
+		w, _, err = p.checkAndUpdateSchemaAndAggregation(w, metric)
+		if err != nil {
+			w, err = whisper.OpenWithOptions(path, &whisper.Options{
+				FLock:      p.flock,
+				Compressed: p.compressed,
+			})
+			if err != nil {
+				p.logger.Error("failed to reopen whisper file after schema migration", zap.String("path", path), zap.Error(p.simplifyPathError(err)))
+				p.popConfirm(metric)
+			}
+			return
+		}
 	}
 
 	values, exists := p.pop(metric)
@@ -517,6 +529,10 @@ func (p *Whisper) Stat(send helper.StatCallback) {
 		total := atomic.LoadUint32(&stat.total)
 		atomic.AddUint32(&stat.total, -total)
 		send("onlineMigration.total", float64(total))
+
+		errors := atomic.LoadUint32(&stat.errors)
+		atomic.AddUint32(&stat.errors, -errors)
+		send("onlineMigration.errors", float64(errors))
 
 		schema := atomic.LoadUint32(&stat.schema)
 		atomic.AddUint32(&stat.schema, -schema)
@@ -681,7 +697,7 @@ func (p *Whisper) checkAndUpdateSchemaAndAggregation(w *whisper.Whisper, metric 
 
 	var virtualSize, physicalSize int64
 	if fiOld, err := w.File().Stat(); err != nil {
-		logger.Error("failed to retrieve file info before migration", zap.String("metric", metric))
+		logger.Error("failed to retrieve file info before migration", zap.String("metric", metric), zap.Error(err))
 	} else {
 		virtualSize = fiOld.Size()
 		physicalSize = virtualSize
@@ -692,7 +708,9 @@ func (p *Whisper) checkAndUpdateSchemaAndAggregation(w *whisper.Whisper, metric 
 
 	// IMPORTANT: file has be re-opened after a call to Whisper.UpdateConfig
 	if err := w.UpdateConfig(retentions, aggregationmethod, xFilesFactor, options); err != nil {
-		logger.Error("failed to migrate/update configs (schema/aggregation/etc)", zap.String("metric", metric))
+		logger.Error("failed to migrate/update configs (schema/aggregation/xff)", zap.String("metric", metric), zap.Error(err))
+		atomic.AddUint32(&p.onlineMigration.stat.errors, 1)
+
 		return w, false, err
 	}
 
@@ -702,8 +720,8 @@ func (p *Whisper) checkAndUpdateSchemaAndAggregation(w *whisper.Whisper, metric 
 		Compressed: p.compressed,
 	})
 
-	if fiNew, err := w.File().Stat(); err != nil {
-		logger.Error("failed to retrieve file info before migration", zap.String("metric", metric))
+	if fiNew, err := nw.File().Stat(); err != nil {
+		logger.Error("failed to retrieve file info after migration", zap.String("metric", metric), zap.Error(err))
 	} else {
 		virtualSizeNew := fiNew.Size()
 		physicalSizeNew := virtualSize

--- a/persister/whisper.go
+++ b/persister/whisper.go
@@ -56,6 +56,25 @@ type Whisper struct {
 	logger                  *zap.Logger
 	createLogger            *zap.Logger
 
+	onlineMigration struct {
+		enabled bool
+		rate    int
+		ticker  *ThrottleTicker
+
+		schema            bool
+		xff               bool
+		aggregationMethod bool
+
+		stat struct {
+			total               uint32
+			schema              uint32
+			xff                 uint32
+			aggregationMethod   uint32
+			physicalSizeChanges int64
+			logicalSizeChanges  int64
+		}
+	}
+
 	// blockThrottleNs        uint64 // sum ns counter
 	// blockQueueGetNs        uint64 // sum ns counter
 	// blockAvoidConcurrentNs uint64 // sum ns counter
@@ -100,6 +119,29 @@ func (p *Whisper) SetMaxCreatesPerSecond(maxCreatesPerSecond int) {
 // SetHardMaxCreatesPerSecond enable throttling
 func (p *Whisper) SetHardMaxCreatesPerSecond(hardMaxCreatesPerSecond bool) {
 	p.hardMaxCreatesPerSecond = hardMaxCreatesPerSecond
+}
+
+// SetOnlineMigration enable online migration
+func (p *Whisper) EnableOnlineMigration(rate int, scope []string) {
+	p.onlineMigration.enabled = true
+	p.onlineMigration.rate = rate
+
+	if len(scope) > 0 {
+		for _, s := range scope {
+			switch s {
+			case "xff":
+				p.onlineMigration.xff = true
+			case "aggregationMethod":
+				p.onlineMigration.aggregationMethod = true
+			case "schema":
+				p.onlineMigration.schema = true
+			}
+		}
+	} else {
+		p.onlineMigration.xff = true
+		p.onlineMigration.aggregationMethod = true
+		p.onlineMigration.schema = true
+	}
 }
 
 // GetMaxUpdatesPerSecond returns current throttling speed
@@ -209,6 +251,7 @@ func (p *Whisper) store(metric string) {
 		path = filepath.Join(p.rootPath, strings.ReplaceAll(metric, ".", "/")+".wsp")
 	}
 
+	var newFile bool
 	w, err := whisper.OpenWithOptions(path, &whisper.Options{
 		FLock:      p.flock,
 		Compressed: p.compressed,
@@ -313,6 +356,14 @@ func (p *Whisper) store(metric string) {
 		)
 
 		atomic.AddUint32(&p.created, 1)
+
+		newFile = true
+	}
+
+	// Check if schema and aggregation is still up-to-date
+	if !newFile && p.onlineMigration.enabled {
+		// errors are logged already
+		w, _, _ = p.checkAndUpdateSchemaAndAggregation(w, metric)
 	}
 
 	values, exists := p.pop(metric)
@@ -457,6 +508,34 @@ func (p *Whisper) Stat(send helper.StatCallback) {
 	send("workers", float64(p.workersCount))
 	send("extended", float64(extended))
 
+	if p.onlineMigration.enabled {
+		stat := &p.onlineMigration.stat
+
+		total := atomic.LoadUint32(&stat.total)
+		atomic.AddUint32(&stat.total, -total)
+		send("onlineMigration.total", float64(total))
+
+		schema := atomic.LoadUint32(&stat.schema)
+		atomic.AddUint32(&stat.schema, -schema)
+		send("onlineMigration.schema", float64(schema))
+
+		xff := atomic.LoadUint32(&stat.xff)
+		atomic.AddUint32(&stat.xff, -xff)
+		send("onlineMigration.xff", float64(xff))
+
+		aggregationMethod := atomic.LoadUint32(&stat.aggregationMethod)
+		atomic.AddUint32(&stat.aggregationMethod, -aggregationMethod)
+		send("onlineMigration.aggregationMethod", float64(aggregationMethod))
+
+		physicalSizeChanges := atomic.LoadInt64(&stat.physicalSizeChanges)
+		atomic.AddInt64(&stat.physicalSizeChanges, -physicalSizeChanges)
+		send("onlineMigration.physicalSizeChanges", float64(physicalSizeChanges))
+
+		logicalSizeChanges := atomic.LoadInt64(&stat.logicalSizeChanges)
+		atomic.AddInt64(&stat.logicalSizeChanges, -logicalSizeChanges)
+		send("onlineMigration.logicalSizeChanges", float64(logicalSizeChanges))
+	}
+
 	// helper.SendAndSubstractUint64("blockThrottleNs", &p.blockThrottleNs, send)
 	// helper.SendAndSubstractUint64("blockQueueGetNs", &p.blockQueueGetNs, send)
 	// helper.SendAndSubstractUint64("blockAvoidConcurrentNs", &p.blockAvoidConcurrentNs, send)
@@ -473,6 +552,10 @@ func (p *Whisper) Start() error {
 			p.maxCreatesTicker = NewThrottleTicker(p.maxCreatesPerSecond)
 		}
 
+		if p.onlineMigration.enabled {
+			p.onlineMigration.ticker = NewHardThrottleTicker(p.onlineMigration.rate)
+		}
+
 		for i := 0; i < p.workersCount; i++ {
 			p.Go(p.worker)
 		}
@@ -485,6 +568,10 @@ func (p *Whisper) Stop() {
 	p.StopFunc(func() {
 		p.throttleTicker.Stop()
 		p.maxCreatesTicker.Stop()
+
+		if p.onlineMigration.ticker != nil {
+			p.onlineMigration.ticker.Stop()
+		}
 	})
 }
 
@@ -517,4 +604,113 @@ func (*Whisper) simplifyPathError(err error) error {
 		return err
 	}
 	return fmt.Errorf("%s: %s", perr.Op, perr.Err)
+}
+
+func (p *Whisper) checkAndUpdateSchemaAndAggregation(w *whisper.Whisper, metric string) (*whisper.Whisper, bool, error) {
+	// TODO: skip check and update if the config files has not been updated
+	// for a long time and all the metrics have been validated? this only
+	// help if the check is expensive, most likely it's not.
+
+	logger := p.logger.Named("online_migration")
+	schema, ok := p.schemas.Match(metric)
+	if !ok {
+		logger.Error("no storage schema defined for metric", zap.String("metric", metric))
+		return w, false, nil
+	}
+	aggr := p.aggregation.Match(metric)
+	if aggr == nil {
+		logger.Error("no storage aggregation defined for metric", zap.String("metric", metric))
+		return w, false, nil
+	}
+
+	compressed := p.compressed
+	if schema.Compressed != nil {
+		compressed = *schema.Compressed
+	}
+	options := &whisper.Options{
+		Sparse:     p.sparse,
+		FLock:      p.flock,
+		Compressed: compressed,
+	}
+
+	retentions := whisper.NewRetentionsNoPointer(w.Retentions())
+	aggregationmethod := w.AggregationMethod()
+	xFilesFactor := w.XFilesFactor()
+	var updateSchema, updateXff, updateAggrMethod bool
+	if schema.canMigrate(p.onlineMigration.schema) && !retentions.Equal(schema.Retentions) {
+		retentions = schema.Retentions
+		updateSchema = true
+	}
+	if aggr.canMigrateXff(p.onlineMigration.xff) && xFilesFactor != float32(aggr.xFilesFactor) {
+		xFilesFactor = float32(aggr.xFilesFactor)
+		updateXff = true
+	}
+	if aggr.canMigrateAggregationMethod(p.onlineMigration.aggregationMethod) && aggregationmethod != aggr.aggregationMethod {
+		aggregationmethod = aggr.aggregationMethod
+		updateAggrMethod = true
+	}
+
+	// No config migration needed.
+	if !updateSchema && !updateXff && !updateAggrMethod {
+		return w, false, nil
+	}
+
+	select {
+	case hasCapacity := <-p.onlineMigration.ticker.C:
+		if !hasCapacity {
+			return w, false, nil
+		}
+	default:
+		// makes sure that it's a non-blocking process
+		return w, false, nil
+	}
+
+	if updateSchema {
+		atomic.AddUint32(&p.onlineMigration.stat.schema, 1)
+	}
+	if updateXff {
+		atomic.AddUint32(&p.onlineMigration.stat.xff, 1)
+	}
+	if updateAggrMethod {
+		atomic.AddUint32(&p.onlineMigration.stat.aggregationMethod, 1)
+	}
+	atomic.AddUint32(&p.onlineMigration.stat.total, 1)
+
+	var virtualSize, physicalSize int64
+	if fiOld, err := w.File().Stat(); err != nil {
+		logger.Error("failed to retrieve file info before migration", zap.String("metric", metric))
+	} else {
+		virtualSize = fiOld.Size()
+		physicalSize = virtualSize
+		if stat, ok := fiOld.Sys().(*syscall.Stat_t); ok {
+			physicalSize = stat.Blocks * 512
+		}
+	}
+
+	// IMPORTANT: file has be re-opened after a call to Whisper.UpdateConfig
+	if err := w.UpdateConfig(retentions, aggregationmethod, xFilesFactor, options); err != nil {
+		logger.Error("failed to migrate/update configs (schema/aggregation/etc)", zap.String("metric", metric))
+		return w, false, err
+	}
+
+	// reopen whisper file
+	nw, err := whisper.OpenWithOptions(w.File().Name(), &whisper.Options{
+		FLock:      p.flock,
+		Compressed: p.compressed,
+	})
+
+	if fiNew, err := w.File().Stat(); err != nil {
+		logger.Error("failed to retrieve file info before migration", zap.String("metric", metric))
+	} else {
+		virtualSizeNew := fiNew.Size()
+		physicalSizeNew := virtualSize
+		if stat, ok := fiNew.Sys().(*syscall.Stat_t); ok {
+			physicalSizeNew = stat.Blocks * 512
+		}
+
+		atomic.AddInt64(&p.onlineMigration.stat.logicalSizeChanges, virtualSizeNew-virtualSize)
+		atomic.AddInt64(&p.onlineMigration.stat.physicalSizeChanges, physicalSizeNew-physicalSize)
+	}
+
+	return nw, true, err
 }

--- a/persister/whisper.go
+++ b/persister/whisper.go
@@ -376,8 +376,8 @@ func (p *Whisper) store(metric string) {
 			if err != nil {
 				p.logger.Error("failed to reopen whisper file after schema migration", zap.String("path", path), zap.Error(p.simplifyPathError(err)))
 				p.popConfirm(metric)
+				return
 			}
-			return
 		}
 	}
 

--- a/persister/whisper_schema.go
+++ b/persister/whisper_schema.go
@@ -22,6 +22,10 @@ type Schema struct {
 	Retentions   whisper.Retentions
 	Priority     int64
 	Compressed   *bool
+
+	// If not specified, migration flag is controlled by the global
+	// migration flag set in persister.Whisper
+	Migration *bool
 }
 
 // WhisperSchemas contains schema settings
@@ -123,9 +127,22 @@ func ReadWhisperSchemas(filename string) (WhisperSchemas, error) {
 			return nil, fmt.Errorf("[persister] Failed to parse compressed %q for [%s]: %s", section["compressed"], schema.Name, "unknown value, please use true/false")
 		}
 
+		if migration, ok := section["migration"]; ok {
+			m := migration == "true"
+			schema.Migration = &m
+		}
+
 		schemas = append(schemas, schema)
 	}
 
 	sort.Sort(schemas)
 	return schemas, nil
+}
+
+func (s *Schema) canMigrate(global bool) bool {
+	if s.Migration != nil {
+		return *s.Migration
+	}
+
+	return global
 }

--- a/tool/persister_configs_differ/main.go
+++ b/tool/persister_configs_differ/main.go
@@ -1,0 +1,107 @@
+package main
+
+import (
+	"bufio"
+	"compress/gzip"
+	"flag"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/go-graphite/go-carbon/persister"
+)
+
+// persister_configs_differ is a tool that we can use to reason the impact of
+// the config changes using file list cache and the new and old config files.
+//
+// usages: ./persister_configs_differ  \
+//         -file-list-cache carbonserver-file-list-cache.gzip  \
+//         -new-aggregation new-storage-aggregation.conf  \
+//         -new-schema new-storage-schemas.conf  \
+//         -old-aggregation oldstorage-aggregation.conf  \
+//         -old-schema old-storage-schemas.conf
+
+// TODO: consider merging it as a sub-command in go-carbon?
+func main() {
+	oldSchemaFile := flag.String("old-schema", "", "old schema file")
+	newSchemaFile := flag.String("new-schema", "", "new schema file")
+	oldAggregationFile := flag.String("old-aggregation", "", "old aggregation file")
+	newAggregationFile := flag.String("new-aggregation", "", "new aggregation file")
+	printMetrics := flag.Bool("print-metrics", false, "print metrics with inconsistent configs")
+	metricsFile := flag.String("file-list-cache", "", "metrics file list cache")
+
+	flag.Parse()
+
+	oldSchemas, err := persister.ReadWhisperSchemas(*oldSchemaFile)
+	if err != nil {
+		panic(err)
+	}
+	newSchemas, err := persister.ReadWhisperSchemas(*newSchemaFile)
+	if err != nil {
+		panic(err)
+	}
+	oldAggregations, err := persister.ReadWhisperAggregation(*oldAggregationFile)
+	if err != nil {
+		panic(err)
+	}
+	newAggregations, err := persister.ReadWhisperAggregation(*newAggregationFile)
+	if err != nil {
+		panic(err)
+	}
+
+	file, err := os.Open(*metricsFile)
+	if err != nil {
+		panic(err)
+	}
+	r, err := gzip.NewReader(file)
+	if err != nil {
+		panic(err)
+	}
+	scanner := bufio.NewScanner(r)
+
+	schemaChanges := map[string]int{}
+	aggregationChanges := map[string]int{}
+	for scanner.Scan() {
+		entry := scanner.Text()
+		if entry == "" || !strings.HasSuffix(entry, ".wsp") {
+			continue
+		}
+		metric := strings.ReplaceAll(strings.TrimSuffix(strings.TrimPrefix(entry, "/"), ".wsp"), "/", ".")
+
+		// log.Printf("metric = %+v\n", metric)
+		//
+		// counter++
+		// if counter%100_000 == 0 {
+		// 	fmt.Printf("count = %+v\n", count)
+		// }
+
+		oldSchema, _ := oldSchemas.Match(metric)
+		newSchema, _ := newSchemas.Match(metric)
+		if !oldSchema.Retentions.Equal(newSchema.Retentions) {
+			// fmt.Println(oldSchema.RetentionStr + "->" + newSchema.RetentionStr)
+			schemaChanges[oldSchema.RetentionStr+"->"+newSchema.RetentionStr] += 1
+
+			if *printMetrics {
+				fmt.Printf("%q,%q,%s,%s,%s\n", oldSchema.RetentionStr, newSchema.RetentionStr, oldSchema.Name, newSchema.Name, metric)
+			}
+		}
+		oldAggregation := oldAggregations.Match(metric)
+		newAggregation := newAggregations.Match(metric)
+		if oldAggregation.AggregationMethod() != newAggregation.AggregationMethod() {
+			// fmt.Println(oldSchema.RetentionStr + "->" + newSchema.RetentionStr)
+			aggregationChanges[oldAggregation.AggregationMethod().String()+"->"+newAggregation.AggregationMethod().String()] += 1
+
+			if *printMetrics {
+				fmt.Printf("%s,%s,%s,%s,%s\n", oldAggregation.AggregationMethod().String(), newAggregation.AggregationMethod().String(), oldAggregation.Name(), newAggregation.Name(), metric)
+			}
+		}
+	}
+	fmt.Println("schema-changes")
+	for rule, count := range schemaChanges {
+		fmt.Println(rule, count)
+	}
+	fmt.Println("aggregation-changes")
+	for rule, count := range aggregationChanges {
+		fmt.Println(rule, count)
+	}
+}

--- a/vendor/github.com/go-graphite/go-whisper/debug.go
+++ b/vendor/github.com/go-graphite/go-whisper/debug.go
@@ -61,6 +61,7 @@ func (whisper *Whisper) CheckIntegrity() error {
 	return nil
 }
 
+// skipcq: RVV-A0005
 func (whisper *Whisper) Dump(all, showDecompressionInfo bool) {
 	debugCompress = showDecompressionInfo
 
@@ -258,6 +259,7 @@ func GenTestArchive(buf []byte, ret Retention) *archiveInfo {
 
 func GenDataPointSlice() []dataPoint { return []dataPoint{} }
 
+// skipcq: RVV-A0005
 func Compare(
 	file1 string,
 	file2 string,

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -56,7 +56,7 @@ github.com/eapache/queue
 # github.com/go-graphite/carbonzipper v0.0.0-20180329125635-fedce067a794
 ## explicit
 github.com/go-graphite/carbonzipper/zipper/httpHeaders
-# github.com/go-graphite/go-whisper v0.0.0-20220503135514-632dcc5beca8
+# github.com/go-graphite/go-whisper v0.0.0-20220504075317-5035f072cad3
 ## explicit
 github.com/go-graphite/go-whisper
 # github.com/go-graphite/protocol v0.4.3-0.20180731190405-5ae324d48067


### PR DESCRIPTION
Historically, if configs are updated in storage-schemas.conf or storage-aggregation.conf, old
metrics would remain unchanged and requires manual delete or migration using whisper-resize.py, etc.

With this PR, go-carbon gains the capability of performing live config migration.
This features used the APIs introduced in https://github.com/go-graphite/go-whisper/pull/25.

There are three new configs introduced in persister:

```
# Enable online whisper file config migration.
#
# To partially enable default migration for only some matched rules in
# storage-schemas.conf or storage-aggregation.conf, we can set
# online-migration-global-scope = "-" and enable the migration in those config
# files.
#
# online-migration-global-scope can also be set any combination of the 3 rules
# as a csv string like: "xff" or "xff,aggregationMethod"
#
# online-migration = false
# online-migration-rate = 5
# online-migration-global-scope = "xff,aggregationMethod,schema"
```

We can also partially enable migration for matched rules by setting online-migration-global-scope to "-"
and tweak the configs in storage-schemas.conf or storage-aggregation.conf.

persister would also emit metrics for this feature for monitoring:

```
persister.onlineMigration.total (counter, total metrics migrated)
persister.onlineMigration.schema (counter, total metrics that have schema migrated)
persister.onlineMigration.xff (counter, total metrics that have xff migrated)
persister.onlineMigration.aggregationMethod (counter, total metrics that aggregationMethod migrated)
persister.onlineMigration.physicalSizeChanges (counter, total physical disk size changes due to config migration)
persister.onlineMigration.logicalSizeChanges (counter, total logical disk size changes due to config migration)
```

---

edit: re-posted [some docs]((https://github.com/go-graphite/go-carbon/pull/438/commits/71f26e01e32e23aceb5a386ad571a5af0a3e76a9)) here for visibility:

### Online config/schema migration

What is online config/schema migration?

it's a process in go-carbon to make sure that metrics are using the right
configurations, if not, it would migrate it to using the right configs.

In general, metrics are always produced with the right configuration specified in
`storage-aggregation.conf` and `storage-schemas.conf` files. However, occasionally,
we might realized that the aggregation method is incorrect for the newly produced
metrics, or the original retention policy is too long or too short. And if we changed
configs now, it would only apply on the new metrics. In order to make sure that
the old metrics are using the right config, we have a few solutions:

* [whisper-resizepy](https://github.com/graphite-project/whisper#whisper-resizepy), [whisper-set-aggregation-methodpy](https://github.com/graphite-project/whisper#whisper-set-aggregation-methodpy), etc.
* Deleting the old metrics and lose the history data.

Manual approach works fine if the data set is not very large. However, automation is always better.

The `online config/schema migration` feature in go-carbon is created to addresses
this issue.

Although it's a nice feature, there are some caveats and limitations. Go-Carbon
tries keep as much history intact as possible. However, depends on the policy
changes, it might not always be possible to do so. Please be careful with the
migration.

**Notable caveats**:

* When applying schema/retention changes, history is only copied if the resolution is the same (See some examples bellow).
* When applying aggregation method changes, histories are not changed.
* It's important to access the file size changes before applying new configs.

Expected changes:

| Policy Changes  | Temporary File  | History | File Size Changes  |
|---|---|---|---|
| XFiles Factor  | Not Needed  | No Changes  |  No Changes |
| Aggregation Method  | Not Needed | No Changes | No Changes |
| Schema Changes  | Required  | Depends  | Depends  |

Some illustrations of schema changes:

| Original Config | New Config | History | File Size Changes  |
|---|---|---|---|
|`1s:2d,1m:31d,1h:2y` | `1s:2d,1m:62d,1h:2y`|Copied in All Archives|Increase|
|`1s:2d,1m:62d,1h:2y` | `1s:2d,1m:31d,1h:2y`|Copied in All Archives, and history in the second archive (`1m:62d`) is truncated to fit the new retention |Reduce|
|`1s:2d,1m:31d` | `1s:2d,5m:31d`|History in first archive is copied, history in the second archive is dropped because the resolution is not the same|Reduce|
|`1s:2d,5m:31d` | `1s:2d,1m:31d` |History in first archive is copied, history in the second archive is dropped because the resolution is not the same|Increase|

---

edit on May 4th:

Updated go-whisper to include bug fixes in cwhisper: https://github.com/go-graphite/go-whisper/pull/32

Also introduce tool/persister_configs_differ for convenience (although it might be better if we turn it into a go-carbon subcommand for greater convenience).