### PR TITLE
Fix carbonserver render error race

### DIFF
--- a/carbonserver/render.go
+++ b/carbonserver/render.go
@@ -545,13 +545,13 @@ func (listener *CarbonserverListener) fetchDataPB3(pathExpression string, files 
 func (listener *CarbonserverListener) fetchDataPB(metric string, files []string, leafs []bool, fromTime, untilTime int32) (*protov2.MultiFetchResponse, error) {
 	var multi protov2.MultiFetchResponse
 	var errs []error
-	for i, metric := range files {
+	for i, fileMetric := range files {
 		if !leafs[i] {
-			listener.logger.Debug("skipping directory", zap.String("metric", metric))
+			listener.logger.Debug("skipping directory", zap.String("metricName", metric), zap.String("fileMetric", fileMetric))
 			// can't fetch a directory
 			continue
 		}
-		response, err := listener.fetchSingleMetricV2(metric, fromTime, untilTime)
+		response, err := listener.fetchSingleMetricV2(fileMetric, fromTime, untilTime)
 		if err == nil {
 			multi.Metrics = append(multi.Metrics, *response)
 		} else {


### PR DESCRIPTION
It is a simple fix to https://github.com/go-graphite/go-carbon/issues/436.

Whenever there are multiple render requests approaching for the
same records, and the proceeding request gets an error, waiting
requests should get an error too.

It is a bit different from #431 because `listener.prepareDataProto` handles the 404 case and returns an empty response which will be handled correctly when it proceeds. So handling the error case would probably be the solution.