### PR TITLE
carbonserver: introduce new max-inflight-requests and no-service-when-index-is-not-ready configs

### DIFF
--- a/carbon/app.go
+++ b/carbon/app.go
@@ -481,6 +481,9 @@ func (app *App) Start(version string) (err error) {
 		carbonserver.SetPercentiles(conf.Carbonserver.Percentiles)
 		// carbonserver.SetQueryTimeout(conf.Carbonserver.QueryTimeout.Value())
 
+		carbonserver.SetMaxInflightRequests(conf.Carbonserver.MaxInflightRequests)
+		carbonserver.SetNoServiceWhenIndexIsNotReady(conf.Carbonserver.NoServiceWhenIndexIsNotReady)
+
 		if app.Config.Whisper.Quotas != nil {
 			if !conf.Carbonserver.ConcurrentIndex || conf.Carbonserver.RealtimeIndex <= 0 {
 				return errors.New("concurrent-index and realtime-index needs to be enabled for quota control.")

--- a/carbon/config.go
+++ b/carbon/config.go
@@ -126,6 +126,9 @@ type carbonserverConfig struct {
 	FileListCache   string `toml:"file-list-cache"`
 
 	QuotaUsageReportFrequency *Duration `toml:"quota-usage-report-frequency"`
+
+	MaxInflightRequests          uint64 `toml:"max-inflight-requests"`
+	NoServiceWhenIndexIsNotReady bool   `toml:"no-service-when-index-is-not-ready"`
 }
 
 type pprofConfig struct {

--- a/deploy/go-carbon.conf
+++ b/deploy/go-carbon.conf
@@ -266,6 +266,29 @@ concurrent-index = false
 # Currently only trie-index is supported. (EXPERIMENTAL)
 realtime-index = 0
 
+# Maximum inflight requests allowed in go-carbon. Default is 0 which means no limit.
+# If limit is reached, go-carbon/carbonserver returns 429 (Too Many Requests).
+# This option would be handy as if there are too many long running requests piling up,
+# it would slows down data ingestion in persister and slows down index building
+# (especially during restart).
+max-inflight-requests = 0
+
+# Returns 503 (Service Unavailable) when go-carbon is still building the first
+# index cache (trie/trigram) after restart. With trie or trigram index,
+# carbonserver falls back to filepath.Glob when index is not ready. And
+# filepath.Glob is expensive and not scaled enough to support some heavy
+# queries (manifested as high usage and frequent GC). Thus it is possible that
+# the read requests is so heavy that it not only slows down index building, it
+# also hinders persister from flushing down data to disk and causing cache.size
+# overflow.
+#
+# By default, it is disabled.
+#
+# It is recommend to enable this flag together with "file-list-cache" (depends on
+# the number of metrics, indexing building with "file-list-cache" is usually
+# much faster than re-scanning the whole file tree after restart).
+no-service-when-index-is-not-ready = false
+
 # This provides the ability to query for new metrics without any wsp files
 # i.e query for metrics present only in cache. Does a cache-scan and
 # populates index with metrics with or without corresponding wsp files,


### PR DESCRIPTION
carbonserver.max-inflight-requests:

    Maximum inflight requests allowed in go-carbon. Default is 0 which means no limit.
    If limit is reached, go-carbon/carbonserver returns 429 (Too Many Requests).
    This option would be handy as if there are too many long running requests piling up,
    it would slows down data ingestion in persister and slows down index building
    (especially during restart).

carbonserver.no-service-when-index-is-not-ready:
  
    Returns 503 (Service Unavailable) when go-carbon is still building the first
    index cache (trie/trigram) after restart. With trie or trigram index,
    carbonserver falls back to filepath.Glob when index is not ready. And
    filepath.Glob is expensive and not scaled enough to support some heavy
    queries (manifested as high usage and frequent GC). Thus it is possible that
    the read requests is so heavy that it not only slows down index building, it
    also hinders persister from flushing down data to disk and causing cache.size
    overflow.
  
    By default, it is disabled.
  
    It is recommend to enable this flag together with "file-list-cache" (depends on
    the number of metrics, indexing building with "file-list-cache" is usually
    much faster than re-scanning the whole file tree after restart).

These two configs could be used to stop carbonserver from starving persister
and indexing goroutines.