### PR TITLE
Makefile: revert .SHELLFLAGS changes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,6 @@ MODULE:=github.com/go-graphite/go-carbon
 
 SHELL := bash
 .ONESHELL:
-.SHELLFLAGS := -eu -o pipefail -c
 
 GO ?= go
 export GOFLAGS +=  -mod=vendor


### PR DESCRIPTION
We are having errors running `make clean && make` due to the flags on linux, not sure the actual cause,
but by removing it, it works both on linux and osx:

```
$ make clean && make
bash: - : invalid option
bash: - : invalid option
rm -f go-carbon build/* *deb *rpm
bash: - : invalid option
make: *** [clean] Error 1
```