### PR TITLE
quota: throughput racy enforcement bug fixes

### DIFF
--- a/carbonserver/list.go
+++ b/carbonserver/list.go
@@ -3,7 +3,6 @@ package carbonserver
 import (
 	"encoding/json"
 	"fmt"
-	"log"
 	"net/http"
 	_ "net/http/pprof"
 	"strconv"
@@ -156,7 +155,6 @@ func (listener *CarbonserverListener) queryMetricsList(query string, limit int, 
 		return nil, errMetricsListEmpty
 	}
 
-	log.Println(strings.ReplaceAll(query, ".", "/"))
 	names, isFiles, nodes, err := fidx.trieIdx.query(strings.ReplaceAll(query, ".", "/"), limit, nil)
 	if err != nil {
 		return nil, err

--- a/carbonserver/trie.go
+++ b/carbonserver/trie.go
@@ -1933,7 +1933,7 @@ func (ti *trieIndex) generateQuotaAndUsageMetrics(prefix, name string, node *tri
 	// WHY: on linux, the maximum filename length is 255, keeping 5 here for
 	// file extension.
 	if len(name) >= 250 {
-		// skipcq: GSC-G401
+		// skipcq: GSC-G401, GO-S1023
 		name = fmt.Sprintf("%s-%x", name[:(250-md5.Size*2-1)], md5.Sum([]byte(name)))
 	}
 

--- a/carbonserver/trie_test.go
+++ b/carbonserver/trie_test.go
@@ -1448,7 +1448,7 @@ func TestTrieQuotaThroughputWithDelayedReset(t *testing.T) {
 
 	// faking failure of throughput usage reset
 	tpe := tindex.throughputs.load("sys.app.server-001")
-	tpe.resetAtv.Store(time.Now().Add(time.Minute * -2))
+	tpe.dpRecorder().resetAt = tpe.dpRecorder().resetAt.Add(time.Minute * -2)
 
 	// failed to perform thoughput usage reset timely, should not throttle metrics in this namespace
 	if tindex.throttle(&points.Points{Metric: "sys.app.server-001.cpu", Data: []points.Point{{}, {}, {}, {}}}, false) {


### PR DESCRIPTION
Three changes are made, but the most important one is __quota: fix a race condition bug in trieIndex.applyQuotas__. The other two commits are by-products of debugging the racy applyQuotas.

quota: fix a race condition bug in trieIndex.applyQuotas

    the current quota config file is last-match-wins, and with heavy concurrent
    quota enforcement, go-carbon should only update quota info per node once,
    otherwise it risks of having confusing and incorrect quota enforcement.

    for example, suppose we have the following quota configs:

        [sys.*]
            throughput = 1024
        [sys.app]
            throughput = 4096

    if sys.app is updated twice using top down order in the quota config file, there
    is a window that sys.app would have a quota with throughput of 1024, and if the
    namespace happen to be receiving more than 1024 data points during that window,
    it would trigger incorrect throttling.

    TODO: with updateChecker, it's also straightforward now to support
    first-match-wins in quota config file, but we would have to introduce a new
    flat to ask for it for backward compatibility.

quota: delay throughput counter update in trieindex.throttle

    When throughput quota usage might be exhausted in a child rule, in the previous implementation,
    the throughput counter would be updated immediately after the check, this might lead to over-accounting
    for parent quota configs.

    The comment changed the implementation to only update the counter if the traffic is confirmed
    to be within quota consumption.

    At the same time, go-carbon also makes sure to report throttled data points for soft throughput quota
    enforcement (i.e. with "none" dropping policy).

quota: refactor throughputUsagePerNamespace usage/quota tracking and enforcement

    The previous implementation has a racy update of throughputUsagePerNamespace.resetAt and dataPoints
    that might potentially lead quota over-enforcement. This commit addess it by wrapping them in one
    struct with atomic updates. The new tradeoff is under-enforcement during counter reset, a better
    tradeoff imo. more details could be found in the commit.