### PR TITLE
carbonserver: introduce file list cache v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -377,7 +377,26 @@ trie-index = false
 # most of the indexing time if it contains a high number of metrics (10
 # - 40 millions). go-carbon only reads the cached file list once after
 # reboot and the cache result is updated after every scan. (EXPERIMENTAL)
-file-list-cache = ""
+#
+# file-list-cache = "/var/lib/carbon/carbonserver-file-list-cache.bin"
+
+# Supported FLC (file list cache) version values are: 2, 1 (default value is 1
+# for backward compatibility).
+#
+# File list cache v2 is is more advanced of file list cache for go-carbon, with
+# good quota support during restarts (by keeping physical, logical sizes, metric
+# creation time in the cache). For more details, see carbonserver/flc.go.
+#
+# V2 file is no longer a plain text file compressed with gzip, but a semi-binary
+# file. For reading flc v2 cache file, use go-carbon with flag -print-file-list-cache:
+#
+#     go-carbon -print-file-list-cache /var/lib/carbon/carbonserver-file-list-cache.bin
+#
+# For upgrade or downgrade to v2 or v1, you can just update the config,
+# go-carbon would transparently detect the existing cache file on restart. No
+# manual deletion needed.
+#
+# file-list-cache-version = 2
 
 # Enable concurrently building index without maintaining a new copy
 # index structure. More memory efficient.

--- a/carbon/app.go
+++ b/carbon/app.go
@@ -502,6 +502,7 @@ func (app *App) Start(version string) (err error) {
 		carbonserver.SetTrieIndex(conf.Carbonserver.TrieIndex)
 		carbonserver.SetConcurrentIndex(conf.Carbonserver.ConcurrentIndex)
 		carbonserver.SetFileListCache(conf.Carbonserver.FileListCache)
+		carbonserver.SetFileListCacheVersion(conf.Carbonserver.FileListCacheVersion)
 		carbonserver.SetInternalStatsDir(conf.Carbonserver.InternalStatsDir)
 		carbonserver.SetPercentiles(conf.Carbonserver.Percentiles)
 		// carbonserver.SetQueryTimeout(conf.Carbonserver.QueryTimeout.Value())

--- a/carbon/config.go
+++ b/carbon/config.go
@@ -126,10 +126,12 @@ type carbonserverConfig struct {
 	MaxMetricsGlobbed  int `toml:"max-metrics-globbed"`
 	MaxMetricsRendered int `toml:"max-metrics-rendered"`
 
-	TrieIndex       bool   `toml:"trie-index"`
-	ConcurrentIndex bool   `toml:"concurrent-index"`
-	RealtimeIndex   int    `toml:"realtime-index"`
-	FileListCache   string `toml:"file-list-cache"`
+	TrieIndex       bool `toml:"trie-index"`
+	ConcurrentIndex bool `toml:"concurrent-index"`
+	RealtimeIndex   int  `toml:"realtime-index"`
+
+	FileListCache        string `toml:"file-list-cache"`
+	FileListCacheVersion int    `toml:"file-list-cache-version"`
 
 	QuotaUsageReportFrequency *Duration `toml:"quota-usage-report-frequency"`
 
@@ -259,13 +261,14 @@ func NewConfig() *Config {
 			WriteTimeout: &Duration{
 				Duration: 60 * time.Second,
 			},
-			QueryCacheEnabled:  true,
-			QueryCacheSizeMB:   0,
-			FindCacheEnabled:   true,
-			TrigramIndex:       true,
-			CacheScan:          false,
-			MaxMetricsGlobbed:  10_000_000,
-			MaxMetricsRendered: 1_000_000,
+			QueryCacheEnabled:    true,
+			QueryCacheSizeMB:     0,
+			FindCacheEnabled:     true,
+			TrigramIndex:         true,
+			CacheScan:            false,
+			MaxMetricsGlobbed:    10_000_000,
+			MaxMetricsRendered:   1_000_000,
+			FileListCacheVersion: 1, // see carbonserver/flc.go
 		},
 		Carbonlink: carbonlinkConfig{
 			Listen:  "127.0.0.1:7002",

--- a/carbonserver/flc.go
+++ b/carbonserver/flc.go
@@ -1,0 +1,343 @@
+package carbonserver
+
+import (
+	"bufio"
+	"bytes"
+	"compress/gzip"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+)
+
+// file list cache
+//
+// why supporting different versions: backward compatibility.
+//
+// principles:
+//   * higher version cache logic should gracefully start from lower version
+//     and upgrade it properly.
+//   * if users decide to go back to the old cache logic (like going back from
+//     v2 to v1), they need to manually remove the existing cache. otherwise,
+//     we would have an undefined behavior in go-carbon (most likely things
+//     are going to be fine, but there is no guarantee).
+//
+// v1 cache contains a simple list of directory and whisper file paths separated
+// by a new line ('\n'), and it's also gzip-ed.
+//
+// v2 cache contains list of whisper file paths, each path also followed by 3
+// stats: logical size, physical size, number of data points. v2 cache is also
+// gzipped. each entry to write to disk using the following format:
+//
+//   [8 bytes: len($whisper_file_path)]
+//   [$whisper_file_path]
+//   [8 bytes: logical_size]
+//   [8 bytes: physical_size]
+//   [8 bytes: data_points]
+//   [8 bytes: first_seen_at]
+//   [1 byte:  \n (0x0a)]
+
+const (
+	// All currently supported flc version numbers.
+	FLCVersionUnspecified FLCVersion = 0
+	FLCVersion1           FLCVersion = 1
+	FLCVersion2           FLCVersion = 2
+
+	// note: there is no v1 magic string as it wasn't designed in the first place.
+	version2MagicString = "\x7fflc02"
+
+	flcv2StatFieldSize      = 8
+	flcv2StatFieldCount     = 4
+	flcv2EntrySeparatorSize = 1
+	flcv2EntryStatLen       = flcv2StatFieldSize*flcv2StatFieldCount + flcv2EntrySeparatorSize
+)
+
+// FLC: file list cache
+type FLCVersion int
+
+// FileListCache lets users interact with the file list cache file.
+type FileListCache interface {
+	GetVersion() FLCVersion
+	Write(*FLCEntry) error
+	Read() (*FLCEntry, error)
+	Close() error
+}
+
+// FLCEntry is an entry in the file list cache.
+type FLCEntry struct {
+	// Shared by both v1 and v2
+	Path string
+
+	// V2 only fields
+	LogicalSize, PhysicalSize, DataPoints int64
+	// Caveat: this is a best effort feature, please treat it with caution.
+	// In theory, this value could be interpreted as file/metric creation time.
+	FirstSeenAt int64
+}
+
+type fileListCacheCommon struct {
+	version FLCVersion
+	path    string
+	mode    byte
+	file    *os.File
+	reader  *gzip.Reader
+	writer  *gzip.Writer
+}
+
+type fileListCacheV1 struct {
+	*fileListCacheCommon
+	scanner *bufio.Scanner
+}
+
+type fileListCacheV2 struct {
+	*fileListCacheCommon
+}
+
+// ReadFileListCache dumps cache data in csv to writer.
+func ReadFileListCache(p string, version FLCVersion, writer io.Writer) error {
+	flc, err := NewFileListCache(p, version, 'r')
+	if err != nil {
+		return err
+	}
+	defer flc.Close()
+
+	switch flc.GetVersion() {
+	case FLCVersion1:
+		fmt.Fprintf(writer, "path\n")
+	case FLCVersion2:
+		fmt.Fprintf(writer, "path,logical_size,physical_size,data_points,first_seen_at\n")
+	}
+
+	for {
+		entry, err := flc.Read()
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				return nil
+			}
+			return err
+		}
+
+		switch flc.GetVersion() {
+		case FLCVersion1:
+			fmt.Fprintf(writer, "%s\n", entry.Path)
+		case FLCVersion2:
+			fmt.Fprintf(writer, "%s,%d,%d,%d,%d\n", entry.Path, entry.LogicalSize, entry.PhysicalSize, entry.DataPoints, entry.FirstSeenAt)
+		}
+	}
+}
+
+// NewFileListCache returns a FileListCache.
+//
+// Supported mode values are: 'r' for read only, 'w' for write only.
+func NewFileListCache(p string, version FLCVersion, mode byte) (FileListCache, error) {
+	var flc FileListCache
+	var flcc = &fileListCacheCommon{
+		version: version,
+		path:    p,
+		mode:    mode,
+	}
+
+	var err error
+	switch flcc.mode {
+	case 'r':
+		flcc.file, err = os.Open(p)
+		if err != nil {
+			return nil, err
+		}
+		flcc.reader, err = gzip.NewReader(flcc.file)
+		if err != nil {
+			return nil, err
+		}
+
+		// FLCVersionUnspecified: if possible, for future flc versions,
+		// go-carbon should be able to transparently detect versions of
+		// the cache file.
+		switch version {
+		case FLCVersion1:
+			flc = newFileListCacheV1ReadOnly(flcc)
+		case FLCVersionUnspecified, FLCVersion2:
+			flcc.version = FLCVersion2                  // for supporting FLCVersionUnspecified
+			flc, err = newFileListCacheV2ReadOnly(flcc) // flcc is already closed if there is error.
+			if err != nil && errors.Is(err, errFLCFallbackToV1) {
+				// transparently detect which cache version is it.
+				return NewFileListCache(p, FLCVersion1, mode)
+			}
+		default:
+			return nil, fmt.Errorf("unknown file list cache version: %d", flcc.version)
+		}
+	case 'w':
+		flcc.file, err = os.Create(p + ".tmp")
+		if err != nil {
+			return nil, err
+		}
+		flcc.writer = gzip.NewWriter(flcc.file)
+
+		// FLCVersionUnspecified is not supported here because go-carbon
+		// need to know what version of flc it needs to generate.
+		switch version {
+		case FLCVersion1:
+			flc = &fileListCacheV1{fileListCacheCommon: flcc}
+		case FLCVersion2:
+			flc = &fileListCacheV2{fileListCacheCommon: flcc}
+
+			if _, err := flc.(*fileListCacheV2).writer.Write([]byte(version2MagicString)); err != nil {
+				flcc.file.Close()
+
+				return nil, err
+			}
+		default:
+			return nil, fmt.Errorf("unknown file list cache version: %d", flcc.version)
+		}
+	}
+
+	return flc, err
+}
+
+// GetVersion returns the version of the file list cache file.
+func (flc *fileListCacheCommon) GetVersion() FLCVersion { return flc.version }
+
+// Closes close the cache file and related writers and readers.
+// For 'w' mode, it also performs a `mv tmp_cache_file cache_file`.
+func (flc *fileListCacheCommon) Close() error {
+	var errs []string
+	if flc.mode == 'w' {
+		if err := flc.writer.Flush(); err != nil {
+			errs = append(errs, fmt.Sprintf("gzip.flush: %s", err))
+		}
+		if err := flc.writer.Close(); err != nil {
+			errs = append(errs, fmt.Sprintf("gzip.close: %s", err))
+		}
+		if err := flc.file.Sync(); err != nil {
+			errs = append(errs, fmt.Sprintf("file.sync: %s", err))
+		}
+	}
+	if err := flc.file.Close(); err != nil {
+		errs = append(errs, fmt.Sprintf("file.sync: %s", err))
+	}
+
+	if flc.mode == 'w' && len(errs) == 0 {
+		if err := os.Rename(flc.path+".tmp", flc.path); err != nil {
+			errs = append(errs, fmt.Sprintf("file.rename: %s", err))
+		}
+	}
+
+	if len(errs) > 0 {
+		return errors.New(strings.Join(errs, ";"))
+	}
+
+	return nil
+}
+
+func newFileListCacheV1ReadOnly(flcc *fileListCacheCommon) *fileListCacheV1 {
+	flc := fileListCacheV1{fileListCacheCommon: flcc}
+	flc.scanner = bufio.NewScanner(flc.reader)
+	return &flc
+}
+
+func (flc *fileListCacheV1) Write(entry *FLCEntry) error {
+	_, err := flc.writer.Write([]byte(entry.Path + "\n"))
+	return err
+}
+
+func (flc *fileListCacheV1) Read() (entry *FLCEntry, err error) {
+	eof := flc.scanner.Scan()
+	if !eof {
+		err = io.EOF
+		return
+	}
+
+	return &FLCEntry{Path: flc.scanner.Text()}, nil
+}
+
+var errFLCFallbackToV1 = errors.New("fallback to flc v1")
+
+func newFileListCacheV2ReadOnly(flcc *fileListCacheCommon) (*fileListCacheV2, error) {
+	flc := fileListCacheV2{
+		fileListCacheCommon: flcc,
+	}
+
+	magic := make([]byte, len(version2MagicString))
+	switch n, err := flc.reader.Read(magic); {
+	case err != nil:
+		return nil, err
+	case n != len(version2MagicString):
+		return nil, fmt.Errorf("failed to read full v2 magic string (%d): %d", len(version2MagicString), n)
+	case !bytes.Equal(magic, []byte(version2MagicString)):
+		// ignoring error here. this path is only run
+		// once by go-carbon. not an actual concern.
+		flc.Close()
+
+		// v1 cache detected, falls back to v1 data
+		return nil, errFLCFallbackToV1
+	}
+
+	return &flc, nil
+}
+
+func (flc *fileListCacheV2) Write(entry *FLCEntry) error {
+	var offset int
+	var buf = make([]byte, flcv2StatFieldSize+len(entry.Path)+flcv2EntryStatLen)
+
+	binary.BigEndian.PutUint64(buf[offset:], uint64(len(entry.Path)))
+	offset += flcv2StatFieldSize
+
+	copy(buf[offset:], []byte(entry.Path))
+	offset += len(entry.Path)
+
+	binary.BigEndian.PutUint64(buf[offset:], uint64(entry.LogicalSize))
+	offset += flcv2StatFieldSize
+
+	binary.BigEndian.PutUint64(buf[offset:], uint64(entry.PhysicalSize))
+	offset += flcv2StatFieldSize
+
+	binary.BigEndian.PutUint64(buf[offset:], uint64(entry.DataPoints))
+	offset += flcv2StatFieldSize
+
+	binary.BigEndian.PutUint64(buf[offset:], uint64(entry.FirstSeenAt))
+	offset += flcv2StatFieldSize
+
+	buf[offset] = '\n'
+
+	_, err := flc.writer.Write(buf)
+
+	return err
+}
+
+func (flc *fileListCacheV2) Read() (entry *FLCEntry, err error) {
+	var plenBuf [8]byte
+	if _, err = io.ReadFull(flc.reader, plenBuf[:]); err != nil {
+		err = fmt.Errorf("flcv2: failed to read path len: %w", err)
+		return
+	}
+	plen := int(binary.BigEndian.Uint64(plenBuf[:]))
+
+	// filepath on linux has a 4k limit, but we are timing it 2 here just to
+	// be flexible and avoid bugs or corruptions to causes panics or oom in
+	// go-carbon
+	//
+	// * https://man7.org/linux/man-pages/man3/realpath.3.html#NOTES
+	// * https://www.ibm.com/docs/en/spectrum-protect/8.1.9?topic=parameters-file-specification-syntax
+	const maxPathLen = 4096 * 2
+	if plen > maxPathLen {
+		err = fmt.Errorf("flcv2: illegal file path length %d (max: %d)", plen, maxPathLen)
+		return
+	}
+
+	data := make([]byte, plen+flcv2EntryStatLen)
+	if _, err = io.ReadFull(flc.reader, data); err != nil {
+		err = fmt.Errorf("flcv2: failed to read full data: %w", err)
+		return
+	}
+
+	entry = &FLCEntry{
+		Path:         string(data[:plen]),
+		LogicalSize:  int64(binary.BigEndian.Uint64(data[plen:])),
+		PhysicalSize: int64(binary.BigEndian.Uint64(data[plen+flcv2StatFieldSize:])),
+		DataPoints:   int64(binary.BigEndian.Uint64(data[plen+flcv2StatFieldSize*2:])),
+		FirstSeenAt:  int64(binary.BigEndian.Uint64(data[plen+flcv2StatFieldSize*3:])),
+	}
+
+	return
+}

--- a/carbonserver/flc_test.go
+++ b/carbonserver/flc_test.go
@@ -1,0 +1,136 @@
+package carbonserver
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"reflect"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestFileListCacheV1(t *testing.T) {
+	defer func() {
+		os.Remove("flc_v1_test.txt")
+		os.Remove("flc_v1_test.txt.tmp")
+	}()
+
+	flcv1w, err := NewFileListCache("flc_v1_test.txt", FLCVersion1, 'w')
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := flcv1w.Write(&FLCEntry{"sys/app/cpu/core0/system.wsp", 1024, 4096, 2048, 1652453112}); err != nil {
+		t.Fatal(err)
+	}
+	if err := flcv1w.Write(&FLCEntry{"sys/app/cpu/core1/system.wsp", 1024, 4096, 2048, 1652453112}); err != nil {
+		t.Fatal(err)
+	}
+	if err := flcv1w.Write(&FLCEntry{"sys/app/cpu/core2/system.wsp", 1024, 4096, 2048, 1652453112}); err != nil {
+		t.Fatal(err)
+	}
+	flcv1w.Close()
+
+	t.Run("v1_reader_with_v1_data", func(t *testing.T) {
+		flcv1r, err := NewFileListCache("flc_v1_test.txt", FLCVersion1, 'r')
+		if err != nil {
+			t.Fatal(err)
+		}
+		var v1data []string
+		for {
+			entry, eof := flcv1r.Read()
+			if eof != nil {
+				break
+			}
+
+			v1data = append(v1data, entry.Path)
+		}
+		flcv1r.Close()
+
+		if got, want := v1data, []string{
+			"sys/app/cpu/core0/system.wsp",
+			"sys/app/cpu/core1/system.wsp",
+			"sys/app/cpu/core2/system.wsp",
+		}; !reflect.DeepEqual(got, want) {
+			t.Errorf("v1data = %s; want %s", got, want)
+		}
+	})
+
+	t.Run("v2_reader_with_v1_data", func(t *testing.T) {
+		flcv2r, err := NewFileListCache("flc_v1_test.txt", FLCVersion2, 'r')
+		if err != nil {
+			t.Fatal(err)
+		}
+		var v2data []string
+		for {
+			entry, eof := flcv2r.Read()
+			if eof != nil {
+				break
+			}
+
+			v2data = append(v2data, entry.Path)
+		}
+		flcv2r.Close()
+
+		if got, want := v2data, []string{
+			"sys/app/cpu/core0/system.wsp",
+			"sys/app/cpu/core1/system.wsp",
+			"sys/app/cpu/core2/system.wsp",
+		}; !reflect.DeepEqual(got, want) {
+			t.Errorf("v2data = %s; want %s", got, want)
+		}
+	})
+}
+
+func TestFileListCacheV2(t *testing.T) {
+	defer func() {
+		os.Remove("flc_v2_test.txt")
+		os.Remove("flc_v2_test.txt.tmp")
+	}()
+
+	flcv2w, err := NewFileListCache("flc_v2_test.txt", FLCVersion2, 'w')
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var testData []*FLCEntry
+	for i := int64(0); i < 409600; i++ {
+		entry := &FLCEntry{
+			Path:         fmt.Sprintf("sys/app/cpu/core-%d/system.wsp", i),
+			DataPoints:   10240 + i,
+			LogicalSize:  40960 + i,
+			PhysicalSize: 20480 + i,
+			FirstSeenAt:  1652453112,
+		}
+		testData = append(testData, entry)
+
+		if err := flcv2w.Write(entry); err != nil {
+			t.Fatal(err)
+		}
+	}
+	flcv2w.Close()
+
+	flcv2r, err := NewFileListCache("flc_v2_test.txt", FLCVersion2, 'r')
+	if err != nil {
+		t.Fatal(err)
+	}
+	var v2data []*FLCEntry
+	for {
+		entry, err := flcv2r.Read()
+		if err != nil {
+			if !errors.Is(err, io.EOF) {
+				t.Error(err)
+			}
+			break
+		}
+
+		v2data = append(v2data, entry)
+	}
+	flcv2r.Close()
+
+	if got, want := v2data, testData; !cmp.Equal(got, want) {
+		t.Errorf("%s", cmp.Diff(got, want))
+	}
+}

--- a/go-carbon.conf.example
+++ b/go-carbon.conf.example
@@ -275,7 +275,26 @@ trie-index = false
 # most of the indexing time if it contains a high number of metrics (10
 # - 40 millions). go-carbon only reads the cached file list once after
 # reboot and the cache result is updated after every scan. (EXPERIMENTAL)
-file-list-cache = ""
+#
+# file-list-cache = "/var/lib/carbon/carbonserver-file-list-cache.bin"
+
+# Supported FLC (file list cache) version values are: 2, 1 (default value is 1
+# for backward compatibility).
+#
+# File list cache v2 is is more advanced of file list cache for go-carbon, with
+# good quota support during restarts (by keeping physical, logical sizes, metric
+# creation time in the cache). For more details, see carbonserver/flc.go.
+#
+# V2 file is no longer a plain text file compressed with gzip, but a semi-binary
+# file. For reading flc v2 cache file, use go-carbon with flag -print-file-list-cache:
+#
+#     go-carbon -print-file-list-cache /var/lib/carbon/carbonserver-file-list-cache.bin
+#
+# For upgrade or downgrade to v2 or v1, you can just update the config,
+# go-carbon would transparently detect the existing cache file on restart. No
+# manual deletion needed.
+#
+# file-list-cache-version = 2
 
 # Enable concurrently building index without maintaining a new copy
 # index structure. More memory efficient.

--- a/go-carbon.go
+++ b/go-carbon.go
@@ -21,6 +21,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/go-graphite/go-carbon/carbon"
+	"github.com/go-graphite/go-carbon/carbonserver"
 	"github.com/go-graphite/go-carbon/points"
 
 	_ "net/http/pprof"
@@ -65,6 +66,7 @@ func main() {
 	pidfile := flag.String("pidfile", "", "Pidfile path (only for daemon)")
 
 	cat := flag.String("cat", "", "Print cache dump file")
+	printFLC := flag.String("print-file-list-cache", "", "Print file list cache. (format: $path_to_cache. example: /var/lib/carbon/carbonserver-file-list-cache.bin)")
 
 	flag.Parse()
 
@@ -83,6 +85,15 @@ func main() {
 		if err != nil {
 			log.Fatal(err)
 		}
+		return
+	}
+
+	if *printFLC != "" {
+		path := *printFLC
+		if err := carbonserver.ReadFileListCache(path, carbonserver.FLCVersionUnspecified, os.Stdout); err != nil {
+			fmt.Fprintf(os.Stderr, "failed to read flc cache: %s\n", err.Error())
+		}
+
 		return
 	}
 


### PR DESCRIPTION
This commit introduces flc v2, the main purpose is to have better quota support during restart.
Mainly for saving physical and logical size info in the flc.

Users can transparently switch from v1 to v2 and vice versa.

More context on quota friendly: with flc v1, when go-carbon is restarted, it would create a trie index
tree using the logical size as physical size for metrics and this would potentially temporary high
physical size accounting and leads to unnecessary throttling if physical size quota is enabled.

With flc v2, go-carbon would keep physical, logical, data points, and first_seen_at timestamp in the 
cache file and use that for rebuilding the trie index after restart. This would avoids temporary incorrect
physical size accounting issues with flcv1.
