### PR TITLE
quota: realtime usage update for metrics, logical/physical sizes, and data points

### DIFF
--- a/carbon/config.go
+++ b/carbon/config.go
@@ -420,6 +420,17 @@ retentions = 60:43200,3600:43800`), 0644)
 
 func (c *Config) getCarbonserverQuotas() (quotas []*carbonserver.Quota) {
 	for _, q := range c.Whisper.Quotas {
+		var transientChild *carbonserver.Quota
+		if q.TransientChildLimit > 0 {
+			transientChild = &carbonserver.Quota{
+				Pattern:        "transient",
+				Metrics:        q.TransientChildLimit,
+				Throughput:     q.TransientChildLimit * 10,
+				IsTransient:    true,
+				DroppingPolicy: carbonserver.QDPNew,
+			}
+		}
+
 		quotas = append(quotas, &carbonserver.Quota{
 			Pattern:          q.Pattern,
 			Namespaces:       q.Namespaces,
@@ -430,6 +441,8 @@ func (c *Config) getCarbonserverQuotas() (quotas []*carbonserver.Quota) {
 			Throughput:       q.Throughput,
 			DroppingPolicy:   carbonserver.ParseQuotaDroppingPolicy(q.DroppingPolicy),
 			StatMetricPrefix: q.StatMetricPrefix,
+
+			TransientChild: transientChild,
 		})
 	}
 

--- a/persister/ini.go
+++ b/persister/ini.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 )
 
+// TODO: migrate to toml?
 func parseIniFile(filename string) ([]map[string]string, error) {
 	body, err := ioutil.ReadFile(filename)
 	if err != nil {

--- a/persister/whisper_quota.go
+++ b/persister/whisper_quota.go
@@ -18,6 +18,8 @@ type Quota struct {
 	Throughput       int64
 	DroppingPolicy   string
 	StatMetricPrefix string
+
+	TransientChildLimit int64
 }
 
 type WhisperQuotas []Quota
@@ -68,6 +70,9 @@ func ReadWhisperQuotas(filename string) (WhisperQuotas, error) {
 			return nil, err
 		}
 		if quota.Throughput, err = parseInt(section, "throughput"); err != nil {
+			return nil, err
+		}
+		if quota.TransientChildLimit, err = parseInt(section, "transient-child-limit"); err != nil {
 			return nil, err
 		}
 


### PR DESCRIPTION
Without this patch, it is possible for some namespaces to have a window of 1-3 `carbonserver.quota-usage-report-frequency`
to conduct quota enforcement penetration.

There are two cases that need to be addressed, dir nodes that are already annotated with proper quota config, nodes that
don't have quota config due to realtime insert via *CarbonserverListener.newMetricsChan.

For annotated nodes, trie index resovle it via realtime metric counter update in *trieIndex.insert.

For unannotated nodes, a new config are introduced, which is called transient-child-limit. With this config, during realtime
insert, trieIndex would annotate the new dir nodes of parent nodes that enables that config. This is not the most proper way
to address the issue, but a trade off of correctness, reliability, complexity, and performance. Re-iterating all quota configs
for every realtime insert is nice but expensive. However, as always, I could be wrong. But this seems to be working in my tests.