### PR TITLE
Add stats for find and render requests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ md5sum
 sha256sum
 *.rpm
 *.deb
+/local/

--- a/carbonserver/carbonserver.go
+++ b/carbonserver/carbonserver.go
@@ -714,7 +714,7 @@ uloop:
 		case <-scanFrequency:
 		case <-force:
 		case <-knownMetricsStatTicker:
-			// It's only useful when uisng realtime index as the
+			// It's only useful when using realtime index as the
 			// scanFrequency should be a long interval/duration
 			// like 2 hours or more, and with concurrent and
 			// realtime index, indexed metrics would grow even without disk scanning.

--- a/carbonserver/carbonserver_test.go
+++ b/carbonserver/carbonserver_test.go
@@ -192,7 +192,7 @@ func testFetchSingleMetricHelper(testData *FetchTest, cache *cache.Cache, carbon
 func TestFetchDataReadBytesMetricIncrement(t *testing.T) {
 	test := getSingleMetricTest("data-file")
 	cache := cache.New()
-	carbonserver, err := getCarbonserverListener(cache)
+	carbonserver, err := initCarbonserverListener(cache)
 	carbonserver.SetTrieIndex(true)
 	if err != nil {
 		t.Fatal(err)
@@ -364,7 +364,7 @@ func getSingleMetricTest(name string) *FetchTest {
 	}
 	return nil
 }
-func getCarbonserverListener(cache *cache.Cache) (*CarbonserverListener, error) {
+func initCarbonserverListener(cache *cache.Cache) (*CarbonserverListener, error) {
 	path, err := ioutil.TempDir("", "")
 	if err != nil {
 		return nil, err
@@ -378,7 +378,7 @@ func getCarbonserverListener(cache *cache.Cache) (*CarbonserverListener, error) 
 
 func testFetchSingleMetricCommon(t *testing.T, test *FetchTest) {
 	cache := cache.New()
-	carbonserver, err := getCarbonserverListener(cache)
+	carbonserver, err := initCarbonserverListener(cache)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -540,7 +540,7 @@ func TestGetMetricsListWithData(t *testing.T) {
 func benchmarkFetchSingleMetricCommon(b *testing.B, test *FetchTest) {
 	cache := cache.New()
 
-	carbonserver, err := getCarbonserverListener(cache)
+	carbonserver, err := initCarbonserverListener(cache)
 	if err != nil {
 		b.Fatal(err)
 	}

--- a/carbonserver/find.go
+++ b/carbonserver/find.go
@@ -209,9 +209,10 @@ func (err errorNotFound) Error() string {
 }
 
 type globs struct {
-	Name  string
-	Files []string
-	Leafs []bool
+	Name      string
+	Files     []string
+	Leafs     []bool
+	TrieNodes []*trieNode
 }
 
 func (listener *CarbonserverListener) findMetrics(ctx context.Context, logger *zap.Logger, t0 time.Time, format responseFormat, names []string) (*findResponse, error) {
@@ -355,7 +356,7 @@ GATHER:
 			glob := globs{
 				Name: expandedResult.Name,
 			}
-			glob.Files, glob.Leafs, err = expandedResult.Files, expandedResult.Leafs, expandedResult.Err
+			glob.Files, glob.Leafs, glob.TrieNodes, err = expandedResult.Files, expandedResult.Leafs, expandedResult.TrieNodes, expandedResult.Err
 			if err != nil {
 				errors = append(errors, fmt.Errorf("%s: %s", expandedResult.Name, err))
 			}

--- a/carbonserver/render.go
+++ b/carbonserver/render.go
@@ -5,7 +5,9 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+
 	"github.com/go-graphite/go-whisper"
+
 	"io/ioutil"
 	"math"
 	"net/http"

--- a/carbonserver/render.go
+++ b/carbonserver/render.go
@@ -5,9 +5,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-
-	"github.com/go-graphite/go-whisper"
-
 	"io/ioutil"
 	"math"
 	"net/http"
@@ -23,6 +20,7 @@ import (
 	"google.golang.org/grpc/status"
 
 	"github.com/go-graphite/carbonzipper/zipper/httpHeaders"
+	"github.com/go-graphite/go-whisper"
 	grpcv2 "github.com/go-graphite/protocol/carbonapi_v2_grpc"
 	protov2 "github.com/go-graphite/protocol/carbonapi_v2_pb"
 	protov3 "github.com/go-graphite/protocol/carbonapi_v3_pb"
@@ -595,7 +593,7 @@ func (listener *CarbonserverListener) fetchData(metric, pathExpression string, f
 			multi = append(multi, response)
 			if listener.trieIndex {
 				readBytesNumber := int64(len(response.Values) * whisper.PointSize) // bytes read from the disc, 12 bytes for each point
-				trieNodes[i].incrementFindBytesMetric(readBytesNumber)
+				trieNodes[i].incrementReadBytesMetric(readBytesNumber)
 			}
 		} else {
 			errs = append(errs, err)

--- a/carbonserver/render.go
+++ b/carbonserver/render.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/go-graphite/go-whisper"
 	"io/ioutil"
 	"math"
 	"net/http"
@@ -392,7 +393,7 @@ func (listener *CarbonserverListener) prepareDataStream(ctx context.Context, for
 
 			listener.logger.Debug("fetching data...")
 			if expandedResult, ok := metricGlobMap[metric.Name]; ok {
-				files, leafs := expandedResult.Files, expandedResult.Leafs
+				files, leafs, trieNodes := expandedResult.Files, expandedResult.Leafs, expandedResult.TrieNodes
 				if len(files) > listener.maxMetricsRendered {
 					listener.accessLogger.Error(
 						"rendering too many metrics",
@@ -402,6 +403,7 @@ func (listener *CarbonserverListener) prepareDataStream(ctx context.Context, for
 
 					files = files[:listener.maxMetricsRendered]
 					leafs = leafs[:listener.maxMetricsRendered]
+					trieNodes = trieNodes[:listener.maxMetricsRendered]
 				}
 
 				metricsCount := 0
@@ -421,10 +423,10 @@ func (listener *CarbonserverListener) prepareDataStream(ctx context.Context, for
 				var res []response
 				var err error
 				if format == protoV2Format || format == jsonFormat {
-					res, err = listener.fetchData(metric.Name, "", files, leafs, fromTime, untilTime)
+					res, err = listener.fetchData(metric.Name, "", files, leafs, trieNodes, fromTime, untilTime)
 				} else {
 					// FIXME: why should we pass metric name instead of path Expression and fill it in afterwards?
-					res, err = listener.fetchData(metric.Name, metric.Name, files, leafs, fromTime, untilTime)
+					res, err = listener.fetchData(metric.Name, metric.Name, files, leafs, trieNodes, fromTime, untilTime)
 					for i := range res {
 						res[i].PathExpression = metric.PathExpression
 					}
@@ -576,7 +578,7 @@ func (listener *CarbonserverListener) prepareDataProto(ctx context.Context, logg
 	return fetchResponse{b, contentType, metricsFetched, valuesFetched, memoryUsed, metrics}, nil
 }
 
-func (listener *CarbonserverListener) fetchData(metric, pathExpression string, files []string, leafs []bool, fromTime, untilTime int32) ([]response, error) {
+func (listener *CarbonserverListener) fetchData(metric, pathExpression string, files []string, leafs []bool, trieNodes []*trieNode, fromTime, untilTime int32) ([]response, error) {
 	var multi []response
 	var errs []error
 	for i, fileName := range files {
@@ -589,6 +591,10 @@ func (listener *CarbonserverListener) fetchData(metric, pathExpression string, f
 		response, err := listener.fetchSingleMetric(fileName, pathExpression, fromTime, untilTime)
 		if err == nil {
 			multi = append(multi, response)
+			if listener.trieIndex {
+				readBytesNumber := int64(len(response.Values) * whisper.PointSize) // bytes read from the disc, 12 bytes for each point
+				trieNodes[i].incrementFindBytesMetric(readBytesNumber)
+			}
 		} else {
 			errs = append(errs, err)
 		}

--- a/carbonserver/trie.go
+++ b/carbonserver/trie.go
@@ -1921,7 +1921,7 @@ func (ti *trieIndex) refreshUsage(throughputs *throughputQuotaManager) (files ui
 					}
 
 					throttled := atomic.LoadInt64(&usage.Throttled)
-					metricName := ti.getMetricName(cur.node, name)
+					metricName := ti.metricName(cur.node, name)
 					ti.generateTrieMetrics(metricName, cur.node, throughput, throttled, cur.readHits, cur.readBytes)
 					if throttled > 0 {
 						atomic.AddInt64(&usage.Throttled, -throttled)
@@ -2367,7 +2367,7 @@ mloop:
 	return toThrottle
 }
 
-func (*trieIndex) getMetricName(node *trieNode, name string) string {
+func (*trieIndex) metricName(node *trieNode, name string) string {
 	var prefix string
 	if quota, ok := node.meta.(*dirMeta).quota.Load().(*Quota); ok {
 		prefix = quota.StatMetricPrefix

--- a/carbonserver/trie.go
+++ b/carbonserver/trie.go
@@ -468,13 +468,13 @@ func (tn *trieNode) setChild(i int, n *trieNode) {
 	)
 }
 
-func (tn *trieNode) incrementFindMetric() {
+func (tn *trieNode) incrementReadHitsMetric() {
 	if tn.file() {
 		meta := tn.meta.(*fileMeta)
 		atomic.AddInt64(&meta.readHits, 1)
 	}
 }
-func (tn *trieNode) incrementFindBytesMetric(bytesNumber int64) {
+func (tn *trieNode) incrementReadBytesMetric(bytesNumber int64) {
 	if tn.file() {
 		meta := tn.meta.(*fileMeta)
 		atomic.AddInt64(&meta.readBytes, bytesNumber)
@@ -1543,7 +1543,7 @@ func (listener *CarbonserverListener) expandGlobsTrie(query string) ([]string, [
 	}
 	// set node as viewed
 	for _, node := range nodes {
-		node.incrementFindMetric()
+		node.incrementReadHitsMetric()
 	}
 	return files, leafs, nodes, nil
 }

--- a/carbonserver/trie.go
+++ b/carbonserver/trie.go
@@ -354,9 +354,9 @@ type fileMeta struct {
 	logicalSize  int64
 	physicalSize int64
 	dataPoints   int64
-
+	readHits     int64 // start only find request + render
 	// a timestamp of the first time when go-carbon has seen this metric.
-	// stricly speacking, it is not metric creation time, but can be used
+	// strictly speaking, it is not metric creation time, but can be used
 	// as a timing reference to infer that the metric is at least created
 	// before this timestamp. some file systems doesn't maintain ctime of
 	// files (like xfs before v5:
@@ -465,6 +465,13 @@ func (tn *trieNode) setChild(i int, n *trieNode) {
 		(*unsafe.Pointer)(unsafe.Pointer(&(*tn.childrens)[i])), // skipcq: GSC-G103
 		unsafe.Pointer(n), // skipcq: GSC-G103
 	)
+}
+
+func (tn *trieNode) incrementFindMetric() {
+	if tn.file() {
+		meta := tn.meta.(*fileMeta)
+		atomic.StoreInt64(&meta.readHits, meta.readHits+1)
+	}
 }
 
 func (ti *trieIndex) trigramsContains(tn *trieNode, t uint32) bool {
@@ -1516,16 +1523,21 @@ func (listener *CarbonserverListener) expandGlobsTrie(query string) ([]string, [
 	var fidx = listener.CurrentFileIndex()
 	var files []string
 	var leafs []bool
+	var nodes []*trieNode
 
 	for _, g := range globs {
-		f, l, _, err := fidx.trieIdx.query(g, listener.maxMetricsGlobbed-len(files), listener.expandGlobBraces)
+		f, l, n, err := fidx.trieIdx.query(g, listener.maxMetricsGlobbed-len(files), listener.expandGlobBraces)
 		if err != nil {
 			return nil, nil, err
 		}
 		files = append(files, f...)
 		leafs = append(leafs, l...)
+		nodes = append(nodes, n...)
 	}
-
+	// set node as viewed
+	for _, node := range nodes {
+		node.incrementFindMetric()
+	}
 	return files, leafs, nil
 }
 
@@ -1853,6 +1865,7 @@ func (ti *trieIndex) refreshUsage(throughputs *throughputQuotaManager) (files ui
 		logicalSize  int64
 		physicalSize int64
 		dataPoints   int64
+		readHits     int64
 	}
 
 	var idx int
@@ -1894,20 +1907,14 @@ func (ti *trieIndex) refreshUsage(throughputs *throughputQuotaManager) (files ui
 						name = ti.root.fullPath('.', nodes)
 						tname = name
 					}
-					var prefix string
-					if quota, ok := cur.node.meta.(*dirMeta).quota.Load().(*Quota); ok {
-						prefix = quota.StatMetricPrefix
-					}
-
 					var throughput int64
 					if te := throughputs.load(tname); te != nil {
 						throughput = te.offset().dataPoints
 					}
 
 					throttled := atomic.LoadInt64(&usage.Throttled)
-
-					ti.generateQuotaAndUsageMetrics(prefix, strings.ReplaceAll(name, ".", "-"), cur.node, throughput, throttled)
-
+					metricName := ti.getMetricName(cur.node, name)
+					ti.generateTrieMetrics(metricName, cur.node, throughput, throttled, cur.readHits)
 					if throttled > 0 {
 						atomic.AddInt64(&usage.Throttled, -throttled)
 					}
@@ -1936,7 +1943,7 @@ func (ti *trieIndex) refreshUsage(throughputs *throughputQuotaManager) (files ui
 			cur.logicalSize += cur.node.meta.(*fileMeta).logicalSize
 			cur.physicalSize += cur.node.meta.(*fileMeta).physicalSize
 			cur.dataPoints += cur.node.meta.(*fileMeta).dataPoints
-
+			cur.readHits += cur.node.meta.(*fileMeta).readHits
 			files++
 
 			goto parent
@@ -1953,7 +1960,7 @@ func (ti *trieIndex) refreshUsage(throughputs *throughputQuotaManager) (files ui
 		logicalSize := cur.logicalSize
 		physicalSize := cur.physicalSize
 		dataPoints := cur.dataPoints
-
+		readHits := cur.readHits
 		states[idx] = state{}
 		idx--
 		if idx < 0 {
@@ -1965,6 +1972,7 @@ func (ti *trieIndex) refreshUsage(throughputs *throughputQuotaManager) (files ui
 		cur.logicalSize += logicalSize
 		cur.physicalSize += physicalSize
 		cur.dataPoints += dataPoints
+		cur.readHits += readHits
 		cur.next++
 
 		continue
@@ -1973,13 +1981,7 @@ func (ti *trieIndex) refreshUsage(throughputs *throughputQuotaManager) (files ui
 	return
 }
 
-func (ti *trieIndex) generateQuotaAndUsageMetrics(prefix, name string, node *trieNode, throughput, throttled int64) {
-	// WHY: on linux, the maximum filename length is 255, keeping 5 here for
-	// file extension.
-	if len(name) >= 250 {
-		// skipcq: GSC-G401, GO-S1023
-		name = fmt.Sprintf("%s-%x", name[:(250-md5.Size*2-1)], md5.Sum([]byte(name)))
-	}
+func (ti *trieIndex) generateTrieMetrics(metricName string, node *trieNode, throughput, throttled, readHits int64) {
 
 	// Note: Timestamp for each points.Points are set by collector send logics
 	meta := node.meta.(*dirMeta)
@@ -1988,13 +1990,13 @@ func (ti *trieIndex) generateQuotaAndUsageMetrics(prefix, name string, node *tri
 		ti.qauMetrics = append(
 			ti.qauMetrics,
 			points.Points{
-				Metric: fmt.Sprintf("quota.namespaces.%s%s", prefix, name),
+				Metric: fmt.Sprintf("quota.namespaces.%s", metricName),
 				Data: []points.Point{{
 					Value: float64(quota.Namespaces),
 				}},
 			},
 			points.Points{
-				Metric: fmt.Sprintf("usage.namespaces.%s%s", prefix, name),
+				Metric: fmt.Sprintf("usage.namespaces.%s", metricName),
 				Data: []points.Point{{
 					Value: float64(atomic.LoadInt64(&meta.usage.Namespaces)),
 				}},
@@ -2004,13 +2006,13 @@ func (ti *trieIndex) generateQuotaAndUsageMetrics(prefix, name string, node *tri
 	if quota.Metrics > 0 {
 		ti.qauMetrics = append(
 			ti.qauMetrics, points.Points{
-				Metric: fmt.Sprintf("quota.metrics.%s%s", prefix, name),
+				Metric: fmt.Sprintf("quota.metrics.%s", metricName),
 				Data: []points.Point{{
 					Value: float64(quota.Metrics),
 				}},
 			},
 			points.Points{
-				Metric: fmt.Sprintf("usage.metrics.%s%s", prefix, name),
+				Metric: fmt.Sprintf("usage.metrics.%s", metricName),
 				Data: []points.Point{{
 					Value: float64(atomic.LoadInt64(&meta.usage.Metrics)),
 				}},
@@ -2021,13 +2023,13 @@ func (ti *trieIndex) generateQuotaAndUsageMetrics(prefix, name string, node *tri
 		ti.qauMetrics = append(
 			ti.qauMetrics,
 			points.Points{
-				Metric: fmt.Sprintf("quota.data_points.%s%s", prefix, name),
+				Metric: fmt.Sprintf("quota.data_points.%s", metricName),
 				Data: []points.Point{{
 					Value: float64(quota.DataPoints),
 				}},
 			},
 			points.Points{
-				Metric: fmt.Sprintf("usage.data_points.%s%s", prefix, name),
+				Metric: fmt.Sprintf("usage.data_points.%s", metricName),
 				Data: []points.Point{{
 					Value: float64(atomic.LoadInt64(&meta.usage.DataPoints)),
 				}},
@@ -2038,13 +2040,13 @@ func (ti *trieIndex) generateQuotaAndUsageMetrics(prefix, name string, node *tri
 		ti.qauMetrics = append(
 			ti.qauMetrics,
 			points.Points{
-				Metric: fmt.Sprintf("quota.logical_size.%s%s", prefix, name),
+				Metric: fmt.Sprintf("quota.logical_size.%s", metricName),
 				Data: []points.Point{{
 					Value: float64(quota.LogicalSize),
 				}},
 			},
 			points.Points{
-				Metric: fmt.Sprintf("usage.logical_size.%s%s", prefix, name),
+				Metric: fmt.Sprintf("usage.logical_size.%s", metricName),
 				Data: []points.Point{{
 					Value: float64(atomic.LoadInt64(&meta.usage.LogicalSize)),
 				}},
@@ -2055,13 +2057,13 @@ func (ti *trieIndex) generateQuotaAndUsageMetrics(prefix, name string, node *tri
 		ti.qauMetrics = append(
 			ti.qauMetrics,
 			points.Points{
-				Metric: fmt.Sprintf("quota.physical_size.%s%s", prefix, name),
+				Metric: fmt.Sprintf("quota.physical_size.%s", metricName),
 				Data: []points.Point{{
 					Value: float64(quota.PhysicalSize),
 				}},
 			},
 			points.Points{
-				Metric: fmt.Sprintf("usage.physical_size.%s%s", prefix, name),
+				Metric: fmt.Sprintf("usage.physical_size.%s", metricName),
 				Data: []points.Point{{
 					Value: float64(atomic.LoadInt64(&meta.usage.PhysicalSize)),
 				}},
@@ -2071,13 +2073,13 @@ func (ti *trieIndex) generateQuotaAndUsageMetrics(prefix, name string, node *tri
 	if quota.Throughput > 0 {
 		ti.qauMetrics = append(
 			ti.qauMetrics, points.Points{
-				Metric: fmt.Sprintf("quota.throughput.%s%s", prefix, name),
+				Metric: fmt.Sprintf("quota.throughput.%s", metricName),
 				Data: []points.Point{{
 					Value: float64(quota.Throughput),
 				}},
 			},
 			points.Points{
-				Metric: fmt.Sprintf("usage.throughput.%s%s", prefix, name),
+				Metric: fmt.Sprintf("usage.throughput.%s", metricName),
 				Data: []points.Point{{
 					Value: float64(throughput),
 				}},
@@ -2086,9 +2088,15 @@ func (ti *trieIndex) generateQuotaAndUsageMetrics(prefix, name string, node *tri
 	}
 
 	ti.qauMetrics = append(ti.qauMetrics, points.Points{
-		Metric: fmt.Sprintf("throttle.%s%s", prefix, name),
+		Metric: fmt.Sprintf("throttle.%s", metricName),
 		Data: []points.Point{{
 			Value: float64(throttled),
+		}},
+	})
+	ti.qauMetrics = append(ti.qauMetrics, points.Points{
+		Metric: fmt.Sprintf("read_hits.%s", metricName),
+		Data: []points.Point{{
+			Value: float64(readHits),
 		}},
 	})
 }
@@ -2336,4 +2344,19 @@ mloop:
 	}
 
 	return toThrottle
+}
+
+func (ti *trieIndex) getMetricName(node *trieNode, name string) string {
+	var prefix string
+	if quota, ok := node.meta.(*dirMeta).quota.Load().(*Quota); ok {
+		prefix = quota.StatMetricPrefix
+	}
+	name = strings.ReplaceAll(name, ".", "-")
+	// WHY: on linux, the maximum filename length is 255, keeping 5 here for
+	// file extension.
+	if len(name) >= 250 {
+		// skipcq: GSC-G401, GO-S1023
+		name = fmt.Sprintf("%s-%x", name[:(250-md5.Size*2-1)], md5.Sum([]byte(name)))
+	}
+	return prefix + name
 }

--- a/carbonserver/trie_test.go
+++ b/carbonserver/trie_test.go
@@ -1464,9 +1464,9 @@ func TestTrieReadMetric(t *testing.T) {
 	tindex.qauMetrics = tindex.qauMetrics[:0]
 	tindex.refreshUsage(tindex.throughputs)
 	expectedMetrics = map[string]points.Points{
-		"read_hits.sys-app-server-001": {Metric: "read_hits.sys-app-server-001", Data: []points.Point{{Value: 1}}},
-		"read_hits.sys-app-server-002": {Metric: "read_hits.sys-app-server-002", Data: []points.Point{{Value: 2}}},
-		"read_hits.root":               {Metric: "read_hits.root", Data: []points.Point{{Value: 3}}},
+		"read_hits.sys-app-server-001": {Metric: "read_hits.sys-app-server-001", Data: []points.Point{{Value: 0}}},
+		"read_hits.sys-app-server-002": {Metric: "read_hits.sys-app-server-002", Data: []points.Point{{Value: 1}}},
+		"read_hits.root":               {Metric: "read_hits.root", Data: []points.Point{{Value: 1}}},
 	}
 	for _, metric := range tindex.qauMetrics {
 		if expectedMetric, ok := expectedMetrics[metric.Metric]; ok {

--- a/carbonserver/trie_test.go
+++ b/carbonserver/trie_test.go
@@ -1268,21 +1268,25 @@ func TestTrieQuotaGeneral(t *testing.T) {
 				{Metric: "usage.metrics.sys-app-srv1-nodes-host-01", Data: []points.Point{{Value: 2}}},
 				{Metric: "throttle.sys-app-srv1-nodes-host-01", Data: []points.Point{{Value: 1}}},
 				{Metric: "read_hits.sys-app-srv1-nodes-host-01", Data: []points.Point{{Value: 0}}},
+				{Metric: "read_bytes.sys-app-srv1-nodes-host-01", Data: []points.Point{{Value: 0}}},
 
 				{Metric: "quota.metrics.sys-app-srv1-nodes-foo-01", Data: []points.Point{{Value: 4}}},
 				{Metric: "usage.metrics.sys-app-srv1-nodes-foo-01", Data: []points.Point{{Value: 3}}},
 				{Metric: "throttle.sys-app-srv1-nodes-foo-01", Data: []points.Point{{Value: 0}}},
 				{Metric: "read_hits.sys-app-srv1-nodes-foo-01", Data: []points.Point{{Value: 0}}},
+				{Metric: "read_bytes.sys-app-srv1-nodes-foo-01", Data: []points.Point{{Value: 0}}},
 
 				{Metric: "quota.metrics.sys-app-srv2-nodes-host-01", Data: []points.Point{{Value: 2}}},
 				{Metric: "usage.metrics.sys-app-srv2-nodes-host-01", Data: []points.Point{{Value: 1}}},
 				{Metric: "throttle.sys-app-srv2-nodes-host-01", Data: []points.Point{{Value: 0}}},
 				{Metric: "read_hits.sys-app-srv2-nodes-host-01", Data: []points.Point{{Value: 0}}},
+				{Metric: "read_bytes.sys-app-srv2-nodes-host-01", Data: []points.Point{{Value: 0}}},
 
 				{Metric: "quota.physical_size.root", Data: []points.Point{{Value: 184320}}},
 				{Metric: "usage.physical_size.root", Data: []points.Point{{Value: 6}}},
 				{Metric: "throttle.root", Data: []points.Point{{Value: 0}}},
 				{Metric: "read_hits.root", Data: []points.Point{{Value: 0}}},
+				{Metric: "read_bytes.root", Data: []points.Point{{Value: 0}}},
 			},
 		},
 	}
@@ -1383,16 +1387,19 @@ func TestTrieQuotaThroughput(t *testing.T) {
 		{Metric: "usage.throughput.sys-app-server-001", Data: []points.Point{{Value: 4}}},
 		{Metric: "throttle.sys-app-server-001", Data: []points.Point{{Value: 4}}},
 		{Metric: "read_hits.sys-app-server-001", Data: []points.Point{{Value: 0}}},
+		{Metric: "read_bytes.sys-app-server-001", Data: []points.Point{{Value: 0}}},
 
 		{Metric: "quota.throughput.sys-app-server-002", Data: []points.Point{{Value: 5}}},
 		{Metric: "usage.throughput.sys-app-server-002", Data: []points.Point{{Value: 0}}},
 		{Metric: "throttle.sys-app-server-002", Data: []points.Point{{Value: 6}}},
 		{Metric: "read_hits.sys-app-server-002", Data: []points.Point{{Value: 0}}},
+		{Metric: "read_bytes.sys-app-server-002", Data: []points.Point{{Value: 0}}},
 
 		{Metric: "quota.physical_size.root", Data: []points.Point{{Value: 184320}}},
 		{Metric: "usage.physical_size.root", Data: []points.Point{{Value: 24576}}},
 		{Metric: "throttle.root", Data: []points.Point{{Value: 0}}},
 		{Metric: "read_hits.root", Data: []points.Point{{Value: 0}}},
+		{Metric: "read_bytes.root", Data: []points.Point{{Value: 0}}},
 	}; !reflect.DeepEqual(tindex.qauMetrics, wants) {
 		t.Errorf("qauMetrics:\n%swants:\n%s", stringifyQuotaPoints(tindex.qauMetrics), stringifyQuotaPoints(wants))
 	}
@@ -1550,16 +1557,19 @@ func TestTrieQuotaThroughputWithDelayedReset(t *testing.T) {
 		{Metric: "usage.throughput.sys-app-server-001", Data: []points.Point{{Value: 8}}},
 		{Metric: "throttle.sys-app-server-001", Data: []points.Point{{Value: 0}}},
 		{Metric: "read_hits.sys-app-server-001", Data: []points.Point{{Value: 0}}},
+		{Metric: "read_bytes.sys-app-server-001", Data: []points.Point{{Value: 0}}},
 
 		{Metric: "quota.throughput.sys-app-server-002", Data: []points.Point{{Value: 4}}},
 		{Metric: "usage.throughput.sys-app-server-002", Data: []points.Point{{Value: 0}}},
 		{Metric: "throttle.sys-app-server-002", Data: []points.Point{{Value: 6}}},
 		{Metric: "read_hits.sys-app-server-002", Data: []points.Point{{Value: 0}}},
+		{Metric: "read_bytes.sys-app-server-002", Data: []points.Point{{Value: 0}}},
 
 		{Metric: "quota.physical_size.root", Data: []points.Point{{Value: 184320}}},
 		{Metric: "usage.physical_size.root", Data: []points.Point{{Value: 24576}}},
 		{Metric: "throttle.root", Data: []points.Point{{Value: 0}}},
 		{Metric: "read_hits.root", Data: []points.Point{{Value: 0}}},
+		{Metric: "read_bytes.root", Data: []points.Point{{Value: 0}}},
 	}; !reflect.DeepEqual(tindex.qauMetrics, wants) {
 		t.Errorf("qauMetrics:\n%swants:\n%s", stringifyQuotaPoints(tindex.qauMetrics), stringifyQuotaPoints(wants))
 	}
@@ -1661,16 +1671,19 @@ func TestTrieQuotaWithProperHierarchicalThroughputEnforcement(t *testing.T) {
 		{Metric: "usage.throughput.sys-app-server-001", Data: []points.Point{{Value: 2}}},
 		{Metric: "throttle.sys-app-server-001", Data: []points.Point{{Value: 1}}},
 		{Metric: "read_hits.sys-app-server-001", Data: []points.Point{{Value: 0}}},
+		{Metric: "read_bytes.sys-app-server-001", Data: []points.Point{{Value: 0}}},
 
 		{Metric: "quota.throughput.sys-app", Data: []points.Point{{Value: 4}}},
 		{Metric: "usage.throughput.sys-app", Data: []points.Point{{Value: 2}}},
 		{Metric: "throttle.sys-app", Data: []points.Point{{Value: 0}}},
 		{Metric: "read_hits.sys-app", Data: []points.Point{{Value: 0}}},
+		{Metric: "read_bytes.sys-app", Data: []points.Point{{Value: 0}}},
 
 		{Metric: "quota.throughput.root", Data: []points.Point{{Value: 4}}},
 		{Metric: "usage.throughput.root", Data: []points.Point{{Value: 2}}},
 		{Metric: "throttle.root", Data: []points.Point{{Value: 0}}},
 		{Metric: "read_hits.root", Data: []points.Point{{Value: 0}}},
+		{Metric: "read_bytes.root", Data: []points.Point{{Value: 0}}},
 	}; !reflect.DeepEqual(tindex.qauMetrics, wants) {
 		t.Errorf("qauMetrics:\n%swants:\n%s", stringifyQuotaPoints(tindex.qauMetrics), stringifyQuotaPoints(wants))
 	}

--- a/carbonserver/trie_test.go
+++ b/carbonserver/trie_test.go
@@ -1267,18 +1267,22 @@ func TestTrieQuotaGeneral(t *testing.T) {
 				{Metric: "quota.metrics.sys-app-srv1-nodes-host-01", Data: []points.Point{{Value: 2}}},
 				{Metric: "usage.metrics.sys-app-srv1-nodes-host-01", Data: []points.Point{{Value: 2}}},
 				{Metric: "throttle.sys-app-srv1-nodes-host-01", Data: []points.Point{{Value: 1}}},
+				{Metric: "read_hits.sys-app-srv1-nodes-host-01", Data: []points.Point{{Value: 0}}},
 
 				{Metric: "quota.metrics.sys-app-srv1-nodes-foo-01", Data: []points.Point{{Value: 4}}},
 				{Metric: "usage.metrics.sys-app-srv1-nodes-foo-01", Data: []points.Point{{Value: 3}}},
 				{Metric: "throttle.sys-app-srv1-nodes-foo-01", Data: []points.Point{{Value: 0}}},
+				{Metric: "read_hits.sys-app-srv1-nodes-foo-01", Data: []points.Point{{Value: 0}}},
 
 				{Metric: "quota.metrics.sys-app-srv2-nodes-host-01", Data: []points.Point{{Value: 2}}},
 				{Metric: "usage.metrics.sys-app-srv2-nodes-host-01", Data: []points.Point{{Value: 1}}},
 				{Metric: "throttle.sys-app-srv2-nodes-host-01", Data: []points.Point{{Value: 0}}},
+				{Metric: "read_hits.sys-app-srv2-nodes-host-01", Data: []points.Point{{Value: 0}}},
 
 				{Metric: "quota.physical_size.root", Data: []points.Point{{Value: 184320}}},
 				{Metric: "usage.physical_size.root", Data: []points.Point{{Value: 6}}},
 				{Metric: "throttle.root", Data: []points.Point{{Value: 0}}},
+				{Metric: "read_hits.root", Data: []points.Point{{Value: 0}}},
 			},
 		},
 	}
@@ -1378,16 +1382,96 @@ func TestTrieQuotaThroughput(t *testing.T) {
 		{Metric: "quota.throughput.sys-app-server-001", Data: []points.Point{{Value: 5}}},
 		{Metric: "usage.throughput.sys-app-server-001", Data: []points.Point{{Value: 4}}},
 		{Metric: "throttle.sys-app-server-001", Data: []points.Point{{Value: 4}}},
+		{Metric: "read_hits.sys-app-server-001", Data: []points.Point{{Value: 0}}},
 
 		{Metric: "quota.throughput.sys-app-server-002", Data: []points.Point{{Value: 5}}},
 		{Metric: "usage.throughput.sys-app-server-002", Data: []points.Point{{Value: 0}}},
 		{Metric: "throttle.sys-app-server-002", Data: []points.Point{{Value: 6}}},
+		{Metric: "read_hits.sys-app-server-002", Data: []points.Point{{Value: 0}}},
 
 		{Metric: "quota.physical_size.root", Data: []points.Point{{Value: 184320}}},
 		{Metric: "usage.physical_size.root", Data: []points.Point{{Value: 24576}}},
 		{Metric: "throttle.root", Data: []points.Point{{Value: 0}}},
+		{Metric: "read_hits.root", Data: []points.Point{{Value: 0}}},
 	}; !reflect.DeepEqual(tindex.qauMetrics, wants) {
 		t.Errorf("qauMetrics:\n%swants:\n%s", stringifyQuotaPoints(tindex.qauMetrics), stringifyQuotaPoints(wants))
+	}
+}
+
+func TestTrieReadMetric(t *testing.T) {
+	input := []string{
+		"/sys/app/server-001/cpu.wsp",
+		"/sys/app/server-002/cpu.wsp",
+	}
+	trieServer := newTrieServer(input, false, t)
+	var tindex = trieServer.CurrentFileIndex().trieIdx
+	tindex.applyQuotas(
+		time.Minute,
+		&Quota{
+			Pattern:      "/",
+			PhysicalSize: 1024 * 12 * 15,
+		},
+		&Quota{
+			Pattern:    "sys.app.*",
+			Throughput: 5,
+		},
+	)
+	resultCh := make(chan *ExpandedGlobResponse, 1)
+	trieServer.expandGlobs(context.TODO(), "sys.app.*.cpu", resultCh) // expect both files to have read metric incr
+	result := <-resultCh
+	trieFiles, err := result.Files, result.Err
+	if err != nil {
+		t.Errorf("failed to trie.expandGlobs: %s", err)
+	}
+	if len(trieFiles) != 2 {
+		t.Errorf("wrong number of globs returned: should be 2 instead of %d", len(trieFiles))
+	}
+
+	tindex.refreshUsage(tindex.throughputs)
+	expectedMetrics := map[string]points.Points{
+		"read_hits.sys-app-server-001": {Metric: "read_hits.sys-app-server-001", Data: []points.Point{{Value: 1}}},
+		"read_hits.sys-app-server-002": {Metric: "read_hits.sys-app-server-002", Data: []points.Point{{Value: 1}}},
+		"read_hits.root":               {Metric: "read_hits.root", Data: []points.Point{{Value: 2}}},
+	}
+	for _, metric := range tindex.qauMetrics {
+		if expectedMetric, ok := expectedMetrics[metric.Metric]; ok {
+			if !reflect.DeepEqual(metric, expectedMetric) {
+				t.Errorf("Metric in qauMetrics:\n%swants:\n%s", fmt.Sprintf("%s %v\n", metric.Metric, metric.Data[0].Value),
+					fmt.Sprintf("%s %v\n", expectedMetric.Metric, expectedMetric.Data[0].Value))
+			}
+			delete(expectedMetrics, metric.Metric)
+		}
+	}
+	if len(expectedMetrics) != 0 {
+		t.Errorf("Not all metrics present\n%T missed metrics", expectedMetrics)
+	}
+	trieServer.expandGlobs(context.TODO(), "sys.app.server-002.cpu", resultCh)
+	result = <-resultCh
+	trieFiles, err = result.Files, result.Err
+	if err != nil {
+		t.Errorf("failed to trie.expandGlobs: %s", err)
+	}
+	if len(trieFiles) != 1 {
+		t.Errorf("wrong number of globs returned: should be 1 instead of %d", len(trieFiles))
+	}
+	tindex.qauMetrics = tindex.qauMetrics[:0]
+	tindex.refreshUsage(tindex.throughputs)
+	expectedMetrics = map[string]points.Points{
+		"read_hits.sys-app-server-001": {Metric: "read_hits.sys-app-server-001", Data: []points.Point{{Value: 1}}},
+		"read_hits.sys-app-server-002": {Metric: "read_hits.sys-app-server-002", Data: []points.Point{{Value: 2}}},
+		"read_hits.root":               {Metric: "read_hits.root", Data: []points.Point{{Value: 3}}},
+	}
+	for _, metric := range tindex.qauMetrics {
+		if expectedMetric, ok := expectedMetrics[metric.Metric]; ok {
+			if !reflect.DeepEqual(metric, expectedMetric) {
+				t.Errorf("Metric in qauMetrics:\n%swants:\n%s", fmt.Sprintf("%s %v\n", metric.Metric, metric.Data[0].Value),
+					fmt.Sprintf("%s %v\n", expectedMetric.Metric, expectedMetric.Data[0].Value))
+			}
+			delete(expectedMetrics, metric.Metric)
+		}
+	}
+	if len(expectedMetrics) != 0 {
+		t.Errorf("Not all metrics present\n%T missed metrics", expectedMetrics)
 	}
 }
 
@@ -1465,14 +1549,17 @@ func TestTrieQuotaThroughputWithDelayedReset(t *testing.T) {
 		{Metric: "quota.throughput.sys-app-server-001", Data: []points.Point{{Value: 4}}},
 		{Metric: "usage.throughput.sys-app-server-001", Data: []points.Point{{Value: 8}}},
 		{Metric: "throttle.sys-app-server-001", Data: []points.Point{{Value: 0}}},
+		{Metric: "read_hits.sys-app-server-001", Data: []points.Point{{Value: 0}}},
 
 		{Metric: "quota.throughput.sys-app-server-002", Data: []points.Point{{Value: 4}}},
 		{Metric: "usage.throughput.sys-app-server-002", Data: []points.Point{{Value: 0}}},
 		{Metric: "throttle.sys-app-server-002", Data: []points.Point{{Value: 6}}},
+		{Metric: "read_hits.sys-app-server-002", Data: []points.Point{{Value: 0}}},
 
 		{Metric: "quota.physical_size.root", Data: []points.Point{{Value: 184320}}},
 		{Metric: "usage.physical_size.root", Data: []points.Point{{Value: 24576}}},
 		{Metric: "throttle.root", Data: []points.Point{{Value: 0}}},
+		{Metric: "read_hits.root", Data: []points.Point{{Value: 0}}},
 	}; !reflect.DeepEqual(tindex.qauMetrics, wants) {
 		t.Errorf("qauMetrics:\n%swants:\n%s", stringifyQuotaPoints(tindex.qauMetrics), stringifyQuotaPoints(wants))
 	}
@@ -1573,14 +1660,17 @@ func TestTrieQuotaWithProperHierarchicalThroughputEnforcement(t *testing.T) {
 		{Metric: "quota.throughput.sys-app-server-001", Data: []points.Point{{Value: 2}}},
 		{Metric: "usage.throughput.sys-app-server-001", Data: []points.Point{{Value: 2}}},
 		{Metric: "throttle.sys-app-server-001", Data: []points.Point{{Value: 1}}},
+		{Metric: "read_hits.sys-app-server-001", Data: []points.Point{{Value: 0}}},
 
 		{Metric: "quota.throughput.sys-app", Data: []points.Point{{Value: 4}}},
 		{Metric: "usage.throughput.sys-app", Data: []points.Point{{Value: 2}}},
 		{Metric: "throttle.sys-app", Data: []points.Point{{Value: 0}}},
+		{Metric: "read_hits.sys-app", Data: []points.Point{{Value: 0}}},
 
 		{Metric: "quota.throughput.root", Data: []points.Point{{Value: 4}}},
 		{Metric: "usage.throughput.root", Data: []points.Point{{Value: 2}}},
 		{Metric: "throttle.root", Data: []points.Point{{Value: 0}}},
+		{Metric: "read_hits.root", Data: []points.Point{{Value: 0}}},
 	}; !reflect.DeepEqual(tindex.qauMetrics, wants) {
 		t.Errorf("qauMetrics:\n%swants:\n%s", stringifyQuotaPoints(tindex.qauMetrics), stringifyQuotaPoints(wants))
 	}


### PR DESCRIPTION
Now each **/find** produces read_hits metrics and each **/render** request produce **read_hits, read_bytes**.  During refreshUsage execution these metrics are sent and flushed.