### PR TITLE
gRPC interceptors

### DIFF
--- a/README.md
+++ b/README.md
@@ -527,6 +527,13 @@ stats-percentiles = [99, 98, 95, 75, 50]
 # [[carbonserver.api-per-path-rate-limiters]]
 # path = "/metrics/list_query/"
 # max-inflight-requests = 3
+# 
+# For gRPC rpcs, path should be full method name.
+#
+# [[carbonserver.api-per-path-rate-limiters]]
+# path = "/carbonapi_v2_grpc.CarbonV2/Render"
+# max-inflight-requests = 10
+# request-timeout = "40s"
 
 # carbonserver.grpc is the configuration for listening for grpc clients.
 # Note: currently, only CarbonV2 Render rpc is implemented.

--- a/carbonserver/carbonserver.go
+++ b/carbonserver/carbonserver.go
@@ -2016,6 +2016,7 @@ func (listener *CarbonserverListener) ListenGRPC(listen string) error {
 	var opts []grpc.ServerOption
 	opts = append(opts, grpc.ChainStreamInterceptor(
 		grpcutil.StreamServerTimeHandler(listener.bucketRequestTimesGRPC),
+		grpcutil.StreamServerStatusMetricHandler(statusCodes, listener.prometheus.request),
 	))
 	grpcServer := grpc.NewServer(opts...) //skipcq: GO-S0902
 	grpcv2.RegisterCarbonV2Server(grpcServer, listener)

--- a/carbonserver/carbonserver.go
+++ b/carbonserver/carbonserver.go
@@ -2014,7 +2014,7 @@ func (listener *CarbonserverListener) ListenGRPC(listen string) error {
 	}
 
 	var opts []grpc.ServerOption
-	opts = append(opts, grpc.ChainUnaryInterceptor(
+	opts = append(opts, grpc.ChainStreamInterceptor(
 		grpcutil.StreamServerTimeHandler(listener.bucketRequestTimesGRPC),
 	))
 	grpcServer := grpc.NewServer(opts...) //skipcq: GO-S0902

--- a/carbonserver/render.go
+++ b/carbonserver/render.go
@@ -480,18 +480,9 @@ func (listener *CarbonserverListener) prepareDataProto(ctx context.Context, logg
 		}
 	}
 
-	select {
-	case <-ctx.Done():
-		switch ctx.Err() {
-		case context.DeadlineExceeded:
-			listener.prometheus.timeoutRequest()
-		case context.Canceled:
-			listener.prometheus.cancelledRequest()
-		}
-
+	if listener.checkRequestCtx(ctx) != nil {
 		err := fmt.Errorf("time out while preparing data proto")
 		return fetchResponse{nil, contentType, 0, 0, 0, nil}, err
-	default:
 	}
 
 	if format == protoV2Format || format == jsonFormat {
@@ -699,17 +690,8 @@ func (listener *CarbonserverListener) Render(req *protov2.MultiFetchRequest, str
 		}
 	}
 
-	select {
-	case <-ctx.Done():
-		switch ctx.Err() {
-		case context.DeadlineExceeded:
-			listener.prometheus.timeoutRequest()
-		case context.Canceled:
-			listener.prometheus.cancelledRequest()
-		}
-
+	if listener.checkRequestCtx(ctx) != nil {
 		return status.New(codes.DeadlineExceeded, "time out while preparing data proto").Err()
-	default:
 	}
 
 	if metricsFetched == 0 && !listener.emptyResultOk {

--- a/go-carbon.conf.example
+++ b/go-carbon.conf.example
@@ -425,6 +425,13 @@ stats-percentiles = [99, 98, 95, 75, 50]
 # [[carbonserver.api-per-path-rate-limiters]]
 # path = "/metrics/list_query/"
 # max-inflight-requests = 3
+#
+# For gRPC rpcs, path should be full method name.
+#
+# [[carbonserver.api-per-path-rate-limiters]]
+# path = "/carbonapi_v2_grpc.CarbonV2/Render"
+# max-inflight-requests = 10
+# request-timeout = "40s"
 
 # carbonserver.grpc is the configuration for listening for grpc clients.
 # Note: currently, only CarbonV2 Render rpc is implemented.

--- a/helper/grpcutil/grpcutil.go
+++ b/helper/grpcutil/grpcutil.go
@@ -2,30 +2,67 @@ package grpcutil
 
 import (
 	"context"
-	"fmt"
+	"github.com/golang/protobuf/proto"
 	"time"
-	
+
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/peer"
 )
 
-func StreamServerTimeHandler(cb func(payload, peer string, t time.Duration)) grpc.UnaryServerInterceptor {
+func UnaryServerTimeHandler(cb func(payload, peer string, t time.Duration)) grpc.UnaryServerInterceptor {
 	return func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (resp interface{}, err error) {
 		t0 := time.Now()
 		defer func() {
 			t := time.Since(t0)
 			var payload string
-			if reqStringer, ok := req.(fmt.Stringer); ok {
+			if reqStringer, ok := req.(proto.Message); ok {
 				payload = reqStringer.String()
 			}
 			var reqPeer string
-			p, ok := peer.FromContext(ctx)
-			if ok {
+			if p, ok := peer.FromContext(ctx); ok {
 				reqPeer = p.Addr.String()
 			}
-			fmt.Println("INTERCEPTED!")
 			cb(payload, reqPeer, t)
 		}()
 		return handler(ctx, req)
 	}
+}
+
+func StreamServerTimeHandler(cb func(payload, peer string, t time.Duration)) grpc.StreamServerInterceptor {
+	return func(srv interface{}, ss grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
+		t0 := time.Now()
+		wss := &wrappedStream{
+			ServerStream: ss,
+		}
+		defer func() {
+			t := time.Since(t0)
+			var reqPeer string
+			if p, ok := peer.FromContext(wss.Context()); ok {
+				reqPeer = p.Addr.String()
+			}
+			cb(wss.payload, reqPeer, t)
+		}()
+		return handler(srv, wss)
+	}
+}
+
+type wrappedStream struct {
+	grpc.ServerStream
+	payload  string
+	gotFirst bool
+}
+
+func (ws *wrappedStream) RecvMsg(m interface{}) error {
+	err := ws.ServerStream.RecvMsg(m)
+	if err != nil {
+		return err
+	}
+	if ws.gotFirst {
+		return nil
+	}
+	if p, ok := m.(proto.Message); ok {
+		ws.payload = p.String()
+	}
+	ws.gotFirst = true
+	return nil
 }

--- a/helper/grpcutil/grpcutil.go
+++ b/helper/grpcutil/grpcutil.go
@@ -1,0 +1,31 @@
+package grpcutil
+
+import (
+	"context"
+	"fmt"
+	"time"
+	
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/peer"
+)
+
+func StreamServerTimeHandler(cb func(payload, peer string, t time.Duration)) grpc.UnaryServerInterceptor {
+	return func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (resp interface{}, err error) {
+		t0 := time.Now()
+		defer func() {
+			t := time.Since(t0)
+			var payload string
+			if reqStringer, ok := req.(fmt.Stringer); ok {
+				payload = reqStringer.String()
+			}
+			var reqPeer string
+			p, ok := peer.FromContext(ctx)
+			if ok {
+				reqPeer = p.Addr.String()
+			}
+			fmt.Println("INTERCEPTED!")
+			cb(payload, reqPeer, t)
+		}()
+		return handler(ctx, req)
+	}
+}

--- a/helper/grpcutil/grpcutil.go
+++ b/helper/grpcutil/grpcutil.go
@@ -49,24 +49,24 @@ func StreamServerTimeHandler(cb func(payload, peer string, t time.Duration)) grp
 	}
 }
 
-func GetWrappedStream(ss grpc.ServerStream) *wrappedStream {
-	if wss, ok := ss.(*wrappedStream); ok {
+func GetWrappedStream(ss grpc.ServerStream) *WrappedStream {
+	if wss, ok := ss.(*WrappedStream); ok {
 		return wss
 	}
-	return &wrappedStream{
+	return &WrappedStream{
 		ServerStream: ss,
 		ctx:          ss.Context(),
 	}
 }
 
-type wrappedStream struct {
+type WrappedStream struct {
 	grpc.ServerStream
 	ctx      context.Context
 	payload  string
 	gotFirst bool
 }
 
-func (ws *wrappedStream) RecvMsg(m interface{}) error {
+func (ws *WrappedStream) RecvMsg(m interface{}) error {
 	err := ws.ServerStream.RecvMsg(m)
 	if err != nil {
 		return err
@@ -81,15 +81,15 @@ func (ws *wrappedStream) RecvMsg(m interface{}) error {
 	return nil
 }
 
-func (ws *wrappedStream) Context() context.Context {
+func (ws *WrappedStream) Context() context.Context {
 	return ws.ctx
 }
 
-func (ws *wrappedStream) SetContext(ctx context.Context) {
+func (ws *WrappedStream) SetContext(ctx context.Context) {
 	ws.ctx = ctx
 }
 
-func (ws *wrappedStream) Payload() string {
+func (ws *WrappedStream) Payload() string {
 	return ws.payload
 }
 


### PR DESCRIPTION
HTTP Middlewares for observability and ratelimiting were not implemented for go-carbon gRPC service. This PR adds those functionality alongside small mandatory refactors in order to have less code copies.

In order to implement middlewares, gRPC interceptors are used, and as currently only Render RPC is implemented which is a stream rpc, stream server interceptors are defined and used. For following RPCs (i.e. Find, Info, etc.) we should have unary stream interceptors as well. Which wouldn't be much different with the current implementations.

Three interceptors are created:
- **StreamServerTimeHandler**: Equivalent to `httputil.TimeHandler` for gRPC stream server.
- **StreamServerStatusMetricHandler**: Implements status-related part of `TraceHandler`. Tracing is not yet implemented for gRPC endpoints.
- **StreamServerRatelimitHandler**: Equivalent to `CarbonserverListener.rateLimitRequest` for gRPC stream server. Some refactor is done here.

A few parts of the middleware logic are still absent for gRPC:
- Tracing
- Connection Tracking (Which seems unused?)