### PR TITLE
Proper enrichFromCache  panic fix and go-whisper upgrade

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -14,14 +14,13 @@ jobs:
         uses: golangci/golangci-lint-action@v2
         with:
           # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
-          version: v1.45.2
+          version: v1.48.0
 
           # Optional: working directory, useful for monorepos
           # working-directory: somedir
 
           # Optional: golangci-lint command line arguments.
-          # TODO: --go 1.17 is added because of https://github.com/golangci/golangci-lint/issues/2649#issuecomment-1070528726
-          args: --enable gofmt,goimports,gocritic --disable errcheck --go 1.17
+          args: --enable gofmt,goimports,gocritic --disable errcheck
 
           # Optional: show only new issues if it's a pull request. The default value is `false`.
           # only-new-issues: true

--- a/carbon/app.go
+++ b/carbon/app.go
@@ -3,7 +3,7 @@ package carbon
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io/ioutil" //nolint:staticcheck
 	"log"
 	"net"
 	"net/url"

--- a/carbon/config.go
+++ b/carbon/config.go
@@ -3,7 +3,7 @@ package carbon
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
+	"io/ioutil" //nolint:staticcheck
 	"log"
 	"path/filepath"
 	"strings"

--- a/carbon/grace.go
+++ b/carbon/grace.go
@@ -3,7 +3,7 @@ package carbon
 import (
 	"bufio"
 	"fmt"
-	"io/ioutil"
+	"io/ioutil" //nolint:staticcheck
 	"os"
 	"path"
 	"sort"

--- a/carbon/restore_test.go
+++ b/carbon/restore_test.go
@@ -1,7 +1,7 @@
 package carbon
 
 import (
-	"io/ioutil"
+	"io/ioutil" //nolint:staticcheck
 	"path"
 	"testing"
 

--- a/carbonserver/cache_index_test.go
+++ b/carbonserver/cache_index_test.go
@@ -3,7 +3,7 @@ package carbonserver
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io/ioutil" //nolint:staticcheck
 	"os"
 	"path/filepath"
 	"testing"

--- a/carbonserver/capability.go
+++ b/carbonserver/capability.go
@@ -2,7 +2,7 @@ package carbonserver
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"io/ioutil" //nolint:staticcheck
 	"net/http"
 	_ "net/http/pprof"
 	"os"

--- a/carbonserver/carbonserver_test.go
+++ b/carbonserver/carbonserver_test.go
@@ -2,7 +2,7 @@ package carbonserver
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io/ioutil" //nolint:staticcheck
 	"math"
 	"os"
 	"path/filepath"

--- a/carbonserver/fetchsinglemetric.go
+++ b/carbonserver/fetchsinglemetric.go
@@ -52,7 +52,9 @@ func (r response) enrichFromCache(listener *CarbonserverListener, cacheData []po
 		}
 		pointsFetchedFromCache++
 		index := (ts - r.StartTime) / r.StepTime
-		r.Values[index] = item.Value
+		if index >= 0 && index < int64(len(r.Values)) {
+			r.Values[index] = item.Value
+		}
 	}
 	waitTime := time.Since(cacheStartTime)
 	atomic.AddUint64(&listener.metrics.CacheWorkTimeNS, uint64(waitTime.Nanoseconds()))

--- a/carbonserver/fetchsinglemetric.go
+++ b/carbonserver/fetchsinglemetric.go
@@ -35,6 +35,16 @@ func (r response) enrichFromCache(listener *CarbonserverListener, cacheData []po
 	atomic.AddUint64(&listener.metrics.CacheRequestsTotal, 1)
 	cacheStartTime := time.Now()
 	pointsFetchedFromCache := 0
+	// extend values array if needed
+	max_index := (r.StopTime - r.StartTime) / r.StepTime
+	start_index := int64(len(r.Values))
+	if start_index < max_index {
+		for i := start_index; i < max_index; i++ {
+			// math.NaN is not working here
+			// values will be replaced when merging with cache
+			r.Values = append(r.Values, 0)
+		}
+	}
 	for _, item := range cacheData {
 		ts := int64(item.Timestamp) - int64(item.Timestamp)%r.StepTime
 		if ts < r.StartTime || ts >= r.StopTime {
@@ -42,10 +52,7 @@ func (r response) enrichFromCache(listener *CarbonserverListener, cacheData []po
 		}
 		pointsFetchedFromCache++
 		index := (ts - r.StartTime) / r.StepTime
-		// TODO: log.debug such cases
-		if index >= 0 && index < int64(len(r.Values)) {
-			r.Values[index] = item.Value
-		}
+		r.Values[index] = item.Value
 	}
 	waitTime := time.Since(cacheStartTime)
 	atomic.AddUint64(&listener.metrics.CacheWorkTimeNS, uint64(waitTime.Nanoseconds()))

--- a/carbonserver/find.go
+++ b/carbonserver/find.go
@@ -5,7 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io/ioutil" //nolint:staticcheck
 	"net/http"
 	_ "net/http/pprof"
 	"strings"

--- a/carbonserver/info.go
+++ b/carbonserver/info.go
@@ -2,7 +2,7 @@ package carbonserver
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"io/ioutil" //nolint:staticcheck
 	"net/http"
 	_ "net/http/pprof"
 	"strings"

--- a/carbonserver/render.go
+++ b/carbonserver/render.go
@@ -5,7 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io/ioutil" //nolint:staticcheck
 	"math"
 	"net/http"
 	_ "net/http/pprof"

--- a/carbonserver/trie.go
+++ b/carbonserver/trie.go
@@ -151,7 +151,8 @@ func (g *gdstate) matched() bool {
 }
 
 // TODO:
-//     add range value validation
+//
+//	add range value validation
 func newGlobState(expr string, expand func(globs []string) ([]string, error)) (*gmatcher, error) {
 	var m = gmatcher{root: &gstate{}, exact: true, expr: expr}
 	var cur = m.root
@@ -1661,14 +1662,17 @@ func (q *throughputUsagePerNamespace) increase(x int64) {
 // throughputUsagePerNamespace.offset  throughputUsagePerNamespace.withinQuota
 // dataPoints -> 1024
 // resetAt    -> now-1m
-//                                     dataPoints -> 1024
+//
+//	dataPoints -> 1024
+//
 // dataPoints -> 0
 // resetAt    -> now
-//                                     resetAt    -> now
 //
-//                                     incorrect quota over enforcement as
-//                                     dataPoints is already 0 by the time
-//                                     withinQuota retrieves resetAt
+//	resetAt    -> now
+//
+//	incorrect quota over enforcement as
+//	dataPoints is already 0 by the time
+//	withinQuota retrieves resetAt
 //
 // the downside of this approach is that go-carbon might still be updating on
 // the counter in the replaced recorder, causing some mis-report or

--- a/carbonserver/trie_real_test.go
+++ b/carbonserver/trie_real_test.go
@@ -1,3 +1,4 @@
+//go:build real
 // +build real
 
 package carbonserver
@@ -6,7 +7,7 @@ import (
 	"context"
 	"flag"
 	"fmt"
-	"io/ioutil"  //nolint:staticcheck
+	"io/ioutil" //nolint:staticcheck
 	"math/rand"
 	"reflect"
 	"runtime/debug"

--- a/carbonserver/trie_real_test.go
+++ b/carbonserver/trie_real_test.go
@@ -6,7 +6,7 @@ import (
 	"context"
 	"flag"
 	"fmt"
-	"io/ioutil"
+	"io/ioutil"  //nolint:staticcheck
 	"math/rand"
 	"reflect"
 	"runtime/debug"

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/dgryski/go-trigram v0.0.0-20160407183937-79ec494e1ad0
 	github.com/dgryski/httputil v0.0.0-20160116060654-189c2918cd08
 	github.com/go-graphite/carbonzipper v0.0.0-20180329125635-fedce067a794
-	github.com/go-graphite/go-whisper v0.0.0-20220706140940-0fdbe10fe673
+	github.com/go-graphite/go-whisper v0.0.0-20220811113531-7b04412de1ae
 	github.com/go-graphite/protocol v1.0.1-0.20220718132526-4b842ba389ee
 	github.com/gogo/protobuf v1.3.2
 	github.com/golang/snappy v0.0.0-20180518054509-2e65f85255db // indirect

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/dgryski/go-trigram v0.0.0-20160407183937-79ec494e1ad0
 	github.com/dgryski/httputil v0.0.0-20160116060654-189c2918cd08
 	github.com/go-graphite/carbonzipper v0.0.0-20180329125635-fedce067a794
-	github.com/go-graphite/go-whisper v0.0.0-20220811113531-7b04412de1ae
+	github.com/go-graphite/go-whisper v0.0.0-20220811123944-7ae7056cf3c0
 	github.com/go-graphite/protocol v1.0.1-0.20220718132526-4b842ba389ee
 	github.com/gogo/protobuf v1.3.2
 	github.com/golang/snappy v0.0.0-20180518054509-2e65f85255db // indirect

--- a/go.sum
+++ b/go.sum
@@ -86,8 +86,8 @@ github.com/go-gl/glfw/v3.3/glfw v0.0.0-20191125211704-12ad95a8df72/go.mod h1:tQ2
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20200222043503-6f7a984d4dc4/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
 github.com/go-graphite/carbonzipper v0.0.0-20180329125635-fedce067a794 h1:9N+1I8z47huAZdcBWVIqfZZPzIzMyXqGd3uR21QN5mA=
 github.com/go-graphite/carbonzipper v0.0.0-20180329125635-fedce067a794/go.mod h1:sfZ+AkP8/bBcWSGVqhseV6t6e/+C0i/PkTpA32W5rXs=
-github.com/go-graphite/go-whisper v0.0.0-20220811113531-7b04412de1ae h1:2P65abeyPH562+HIfr3gMiY1p3XpUrpHrB9SpkbfC7M=
-github.com/go-graphite/go-whisper v0.0.0-20220811113531-7b04412de1ae/go.mod h1:1edRhfqJoiHSjN72nYptHK0YR4yYt8aPC4NRHWhT0XE=
+github.com/go-graphite/go-whisper v0.0.0-20220811123944-7ae7056cf3c0 h1:eUcmhaQSskwmKVC1kDGypiJR2NhalzrIrnzagHh7Cxk=
+github.com/go-graphite/go-whisper v0.0.0-20220811123944-7ae7056cf3c0/go.mod h1:1edRhfqJoiHSjN72nYptHK0YR4yYt8aPC4NRHWhT0XE=
 github.com/go-graphite/protocol v1.0.1-0.20220718132526-4b842ba389ee h1:Sb63UbLUOXtKFIfNfZIkWrs73vWD0ZKzrBdTjvlVOBQ=
 github.com/go-graphite/protocol v1.0.1-0.20220718132526-4b842ba389ee/go.mod h1:puWkW2DFZi46CaLY1rxYhkDiBDFlpaTDaMjcE/Cd9gw=
 github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=

--- a/go.sum
+++ b/go.sum
@@ -86,8 +86,8 @@ github.com/go-gl/glfw/v3.3/glfw v0.0.0-20191125211704-12ad95a8df72/go.mod h1:tQ2
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20200222043503-6f7a984d4dc4/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
 github.com/go-graphite/carbonzipper v0.0.0-20180329125635-fedce067a794 h1:9N+1I8z47huAZdcBWVIqfZZPzIzMyXqGd3uR21QN5mA=
 github.com/go-graphite/carbonzipper v0.0.0-20180329125635-fedce067a794/go.mod h1:sfZ+AkP8/bBcWSGVqhseV6t6e/+C0i/PkTpA32W5rXs=
-github.com/go-graphite/go-whisper v0.0.0-20220706140940-0fdbe10fe673 h1:KXBNR5tGEMaq2ZOtUNgRdPEJc5LfNFUQj8LGsaRyeXA=
-github.com/go-graphite/go-whisper v0.0.0-20220706140940-0fdbe10fe673/go.mod h1:1edRhfqJoiHSjN72nYptHK0YR4yYt8aPC4NRHWhT0XE=
+github.com/go-graphite/go-whisper v0.0.0-20220811113531-7b04412de1ae h1:2P65abeyPH562+HIfr3gMiY1p3XpUrpHrB9SpkbfC7M=
+github.com/go-graphite/go-whisper v0.0.0-20220811113531-7b04412de1ae/go.mod h1:1edRhfqJoiHSjN72nYptHK0YR4yYt8aPC4NRHWhT0XE=
 github.com/go-graphite/protocol v1.0.1-0.20220718132526-4b842ba389ee h1:Sb63UbLUOXtKFIfNfZIkWrs73vWD0ZKzrBdTjvlVOBQ=
 github.com/go-graphite/protocol v1.0.1-0.20220718132526-4b842ba389ee/go.mod h1:puWkW2DFZi46CaLY1rxYhkDiBDFlpaTDaMjcE/Cd9gw=
 github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=

--- a/helper/atomicfiles/atomicfiles.go
+++ b/helper/atomicfiles/atomicfiles.go
@@ -1,7 +1,7 @@
 package atomicfiles
 
 import (
-	"io/ioutil"
+	"io/ioutil" //nolint:staticcheck
 	"os"
 	"path"
 )

--- a/helper/qa/tmp_dir.go
+++ b/helper/qa/tmp_dir.go
@@ -1,7 +1,7 @@
 package qa
 
 import (
-	"io/ioutil"
+	"io/ioutil" //nolint:staticcheck
 	"os"
 	"testing"
 )

--- a/persister/ini.go
+++ b/persister/ini.go
@@ -3,7 +3,7 @@ package persister
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
+	"io/ioutil" //nolint:staticcheck
 	"strings"
 )
 

--- a/persister/throttle.go
+++ b/persister/throttle.go
@@ -8,13 +8,13 @@ import (
 
 // ThrottleTicker is a ticker that can be used for hard or soft rate-limiting.
 //
-// * A soft rate limiter will send a message on C at the actual rate that is
-//   specified.
+//   - A soft rate limiter will send a message on C at the actual rate that is
+//     specified.
 //
-// * A hard rate limiter may send arbitrarily many messages on C every second,
-//   but it will send the value 'true' with the first ratePerSec ones, and
-//   'false' with all subsequent ones, until the next second. It is up to the
-//   user to decide what to do in each case.
+//   - A hard rate limiter may send arbitrarily many messages on C every second,
+//     but it will send the value 'true' with the first ratePerSec ones, and
+//     'false' with all subsequent ones, until the next second. It is up to the
+//     user to decide what to do in each case.
 type ThrottleTicker struct {
 	helper.Stoppable
 	C chan bool

--- a/persister/whisper_schema_test.go
+++ b/persister/whisper_schema_test.go
@@ -1,7 +1,7 @@
 package persister
 
 import (
-	"io/ioutil"
+	"io/ioutil" //nolint:staticcheck
 	"os"
 	"testing"
 

--- a/points/points.go
+++ b/points/points.go
@@ -116,7 +116,8 @@ func (p *Points) WriteBinaryTo(w io.Writer) (n int, err error) {
 }
 
 // ParseText parse text protocol Point
-//  host.Point.value 42 1422641531\n
+//
+//	host.Point.value 42 1422641531\n
 func ParseText(line string) (*Points, error) {
 
 	row := strings.Split(strings.Trim(line, "\n \t\r"), " ")

--- a/receiver/http/http.go
+++ b/receiver/http/http.go
@@ -2,7 +2,7 @@ package http
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io/ioutil" //nolint:staticcheck
 	"net"
 	"net/http"
 	"sync/atomic"

--- a/receiver/kafka/kafka.go
+++ b/receiver/kafka/kafka.go
@@ -7,7 +7,7 @@ import (
 
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io/ioutil" //nolint:staticcheck
 	"strings"
 	"sync"
 	"time"

--- a/receiver/pubsub/pubsub.go
+++ b/receiver/pubsub/pubsub.go
@@ -6,7 +6,7 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
+	"io/ioutil" //nolint:staticcheck
 	"sync"
 	"sync/atomic"
 	"time"

--- a/tags/tags.go
+++ b/tags/tags.go
@@ -2,7 +2,7 @@ package tags
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io/ioutil" //nolint:staticcheck
 	"net/http"
 	"net/url"
 	"sync/atomic"

--- a/vendor/github.com/go-graphite/go-whisper/whisper.go
+++ b/vendor/github.com/go-graphite/go-whisper/whisper.go
@@ -1287,27 +1287,22 @@ func (whisper *Whisper) fetchFromArchive(archive *archiveInfo, fromTime, untilTi
 		if err != nil {
 			return nil, err
 		}
-		// create values array with same size as feteched data
-		// otherwise merging logic below breaks
-		values := make([]float64, len(series))
+
+		irange := untilInterval - fromInterval
+		values := make([]float64, irange/archive.secondsPerPoint)
+		
 		for i := range values {
 			values[i] = math.NaN()
 		}
-		// fetched data can be out of order (because of archive)
+		// fetched data can be out of order (because of buffer)
 		// so, let's sort it out
 		step := archive.secondsPerPoint
 		for _, dPoint := range series {
-			index := (dPoint.interval - fromInterval) / step
-			// protect values' bounds
+			index := (dPoint.interval - fromInterval) / archive.secondsPerPoint
 			if index >= len(values) || index < 0 {
-				break
+				continue
 			}
 			values[index] = dPoint.value
-		}
-		// cut values up to interval
-		values_tgt := (untilInterval - fromInterval) / step
-		if len(values) > values_tgt {
-			values = values[:values_tgt]
 		}
 		return &TimeSeries{fromInterval, untilInterval, step, values}, nil
 	} else {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -56,7 +56,7 @@ github.com/eapache/queue
 # github.com/go-graphite/carbonzipper v0.0.0-20180329125635-fedce067a794
 ## explicit
 github.com/go-graphite/carbonzipper/zipper/httpHeaders
-# github.com/go-graphite/go-whisper v0.0.0-20220811113531-7b04412de1ae
+# github.com/go-graphite/go-whisper v0.0.0-20220811123944-7ae7056cf3c0
 ## explicit; go 1.18
 github.com/go-graphite/go-whisper
 # github.com/go-graphite/protocol v1.0.1-0.20220718132526-4b842ba389ee

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -56,7 +56,7 @@ github.com/eapache/queue
 # github.com/go-graphite/carbonzipper v0.0.0-20180329125635-fedce067a794
 ## explicit
 github.com/go-graphite/carbonzipper/zipper/httpHeaders
-# github.com/go-graphite/go-whisper v0.0.0-20220706140940-0fdbe10fe673
+# github.com/go-graphite/go-whisper v0.0.0-20220811113531-7b04412de1ae
 ## explicit; go 1.18
 github.com/go-graphite/go-whisper
 # github.com/go-graphite/protocol v1.0.1-0.20220718132526-4b842ba389ee


### PR DESCRIPTION
- proper fix for enrichFromCache panic. Extending array with 0, tried NaN but it's immediately failing during marshalling, obviously. 
- upgrading go-whisper to include [buffer merge fix](https://github.com/go-graphite/go-whisper/pull/35).