### PR TITLE
add into access log "complexity" of find request

### DIFF
--- a/carbonserver/carbonserver.go
+++ b/carbonserver/carbonserver.go
@@ -126,7 +126,7 @@ type ExpandedGlobResponse struct {
 	Files     []string
 	Leafs     []bool
 	TrieNodes []*trieNode
-	Lookups   uint64
+	Lookups   uint32
 	Err       error
 }
 

--- a/carbonserver/carbonserver.go
+++ b/carbonserver/carbonserver.go
@@ -130,7 +130,7 @@ type ExpandedGlobResponse struct {
 	Files     []string
 	Leafs     []bool
 	TrieNodes []*trieNode
-	Lookups   uint64
+	Lookups   uint32
 	Err       error
 }
 

--- a/carbonserver/find.go
+++ b/carbonserver/find.go
@@ -26,7 +26,7 @@ type findResponse struct {
 	data        []byte
 	contentType string
 	files       int
-	lookups     uint64
+	lookups     uint32
 }
 
 func (listener *CarbonserverListener) findHandler(wr http.ResponseWriter, req *http.Request) {
@@ -194,7 +194,7 @@ func (listener *CarbonserverListener) findHandler(wr http.ResponseWriter, req *h
 		zap.Bool("find_cache_enabled", listener.findCacheEnabled),
 		zap.Bool("from_cache", fromCache),
 		zap.Int("http_code", http.StatusOK),
-		zap.Uint64("lookups", response.lookups),
+		zap.Uint32("lookups", response.lookups),
 	)
 	span.SetAttributes(
 		kv.Int("graphite.files", response.files),
@@ -215,7 +215,7 @@ type globs struct {
 	Files     []string
 	Leafs     []bool
 	TrieNodes []*trieNode
-	Lookups   uint64
+	Lookups   uint32
 }
 
 func (listener *CarbonserverListener) findMetrics(ctx context.Context, logger *zap.Logger, t0 time.Time, format responseFormat, names []string) (*findResponse, error) {
@@ -322,7 +322,7 @@ func (listener *CarbonserverListener) findMetrics(ctx context.Context, logger *z
 		var metrics []map[string]interface{}
 		var m map[string]interface{}
 		files := 0
-		var lookups uint64
+		var lookups uint32
 
 		glob := expandedGlobs[0]
 		files += len(glob.Files)

--- a/carbonserver/list.go
+++ b/carbonserver/list.go
@@ -155,7 +155,7 @@ func (listener *CarbonserverListener) queryMetricsList(query string, limit int, 
 		return nil, errMetricsListEmpty
 	}
 
-	names, isFiles, nodes, err := fidx.trieIdx.query(strings.ReplaceAll(query, ".", "/"), limit, nil)
+	names, isFiles, nodes, _, err := fidx.trieIdx.query(strings.ReplaceAll(query, ".", "/"), limit, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/carbonserver/trie.go
+++ b/carbonserver/trie.go
@@ -759,7 +759,7 @@ func (ti *trieIndex) newDir() *trieNode {
 //   but we should be able to calculate max required depth based on expr, we don't have to look into deeper levels than expr's depth unless there is some unknown corner case exist
 // - get rid of 'goto', since it adds complexions
 //
-func (ti *trieIndex) query(expr string, limit int, expand func(globs []string) ([]string, error)) (files []string, isFiles []bool, nodes []*trieNode, its uint64, err error) {
+func (ti *trieIndex) query(expr string, limit int, expand func(globs []string) ([]string, error)) (files []string, isFiles []bool, nodes []*trieNode, its uint32, err error) {
 	expr = strings.TrimSpace(expr)
 	if expr == "" {
 		expr = "*"
@@ -772,7 +772,7 @@ func (ti *trieIndex) query(expr string, limit int, expand func(globs []string) (
 	// to test if it works properly
 	var exact bool
 	// complexity of query
-	var lookups uint64
+	var lookups uint32
 	for _, node := range strings.Split(expr, "/") {
 		if node == "" {
 			continue
@@ -801,7 +801,7 @@ func (ti *trieIndex) query(expr string, limit int, expand func(globs []string) (
 	var trieNodes = make([]*trieNode, depth)
 	// each item contains an array of all children for every trieNode in current looking path
 	var childrensStack = make([][]*trieNode, depth)
-	//current searching depth
+	// current searching depth
 	var ncindex int
 	// index of needed matcher
 	var mindex int
@@ -1537,7 +1537,7 @@ func (ti *trieIndex) countNodes() (count, files, dirs, onec, onefc, onedc int, c
 	return
 }
 
-func (listener *CarbonserverListener) expandGlobsTrie(query string) ([]string, []bool, []*trieNode, uint64, error) {
+func (listener *CarbonserverListener) expandGlobsTrie(query string) ([]string, []bool, []*trieNode, uint32, error) {
 	query = strings.ReplaceAll(query, ".", "/")
 	globs := []string{query}
 
@@ -1565,7 +1565,7 @@ func (listener *CarbonserverListener) expandGlobsTrie(query string) ([]string, [
 	var files []string
 	var leafs []bool
 	var nodes []*trieNode
-	var lookups uint64
+	var lookups uint32
 
 	for _, g := range globs {
 		f, l, n, lk, err := fidx.trieIdx.query(g, listener.maxMetricsGlobbed-len(files), listener.expandGlobBraces)

--- a/carbonserver/trie.go
+++ b/carbonserver/trie.go
@@ -752,37 +752,59 @@ func (ti *trieIndex) newDir() *trieNode {
 
 // TODO: add some defensive logics agains bad queries?
 // depth first search
-func (ti *trieIndex) query(expr string, limit int, expand func(globs []string) ([]string, error)) (files []string, isFiles []bool, nodes []*trieNode, err error) {
+// TODO: refactor to make the function more readable. Some ideas:
+// - to isolate Depth first search in separate class
+// - probably we can optimize the length of existed arrays. It uses tree depth + 7, where tree depth is the longest path in the tree in characters
+//   but we should be able to calculate max required depth based on expr, we don't have to look into deeper levels than expr's depth unless there is some unknown corner case exist
+// - get rid of 'goto', since it adds complexions
+//
+func (ti *trieIndex) query(expr string, limit int, expand func(globs []string) ([]string, error)) (files []string, isFiles []bool, nodes []*trieNode, its uint64, err error) {
 	expr = strings.TrimSpace(expr)
 	if expr == "" {
 		expr = "*"
 	}
-	var matchers []*gmatcher
+	var matchers []*gmatcher // information about matching texts, has bytes array with used characters, one matcher per one depth level
+
+	// TODO:
+	// Supposely it indicates that we look for just one exact path, and it stops search after finding one path
+	// but it is always false in current code. 'exact' should be true by default
+	// to test if it works properly
 	var exact bool
+	// complexity of query
+	var lookups uint64
 	for _, node := range strings.Split(expr, "/") {
 		if node == "" {
 			continue
 		}
 		gs, err := newGlobState(node, expand)
 		if err != nil {
-			return nil, nil, nil, err
+			return nil, nil, nil, lookups, err
 		}
 		exact = exact && gs.exact
 		matchers = append(matchers, gs)
 	}
 
 	if len(matchers) == 0 {
-		return nil, nil, nil, nil
+		return nil, nil, nil, lookups, nil
 	}
 
+	// current node
 	var cur = ti.root
+	// children of current node
 	var curChildrens = cur.getChildrens()
+	// longest path in trie (length in characters) + 7 (some magic number for extra capacity)
 	var depth = ti.getDepth() + trieDepthBuffer
+	// array of child indexes we looked at last time
 	var nindex = make([]int, depth)
+	// array of nodes, contains the path to the current processed node
 	var trieNodes = make([]*trieNode, depth)
+	// each item contains an array of all children for every trieNode in current looking path
 	var childrensStack = make([][]*trieNode, depth)
+	//current searching depth
 	var ncindex int
+	// index of needed matcher
 	var mindex int
+	//// matcher for the current level depth
 	var curm = matchers[0]
 	var ndstate *gdstate
 	var isFile, isDir, hasMoreNodes bool
@@ -794,11 +816,14 @@ func (ti *trieIndex) query(expr string, limit int, expand func(globs []string) (
 			goto parent
 		}
 
+		// starting processing children of current node and saving current node into path
+		// the root is supposed to be '/' node, not containing useful information, we skip checking it
 		trieNodes[ncindex] = cur
 		childrensStack[ncindex] = curChildrens
 		cur = cur.getChild(curChildrens, nindex[ncindex])
 		curChildrens = cur.getChildrens()
 		ncindex++
+		lookups++
 
 		// It's possible to run into a situation of newer and longer metrics
 		// are added during the query, for such situation, it's safer to just
@@ -807,7 +832,10 @@ func (ti *trieIndex) query(expr string, limit int, expand func(globs []string) (
 			goto parent
 		}
 
+		// if node is '/'
 		if cur.dir() {
+			// amount of matchers should correlate the max searching depth,
+			// first condition: checking the depth is too deep it doesn't make sense, going to parent
 			if mindex+1 >= len(matchers) || !curm.dstate().matched() || len(curChildrens) == 0 {
 				goto parent
 			}
@@ -819,6 +847,7 @@ func (ti *trieIndex) query(expr string, limit int, expand func(globs []string) (
 			continue
 		}
 
+		// matching regexp
 		if curm.lsComplex && len(curm.trigrams) > 0 {
 			if _, ok := ti.trigrams[cur]; ok {
 				for _, t := range curm.trigrams {
@@ -829,6 +858,7 @@ func (ti *trieIndex) query(expr string, limit int, expand func(globs []string) (
 			}
 		}
 
+		// matching regexp
 		for i := 0; i < len(cur.c); i++ {
 			ndstate = curm.dstate().step(cur.c[i])
 			if len(ndstate.gstates) == 0 {
@@ -875,6 +905,7 @@ func (ti *trieIndex) query(expr string, limit int, expand func(globs []string) (
 			goto parent
 		}
 
+		// we found result metric here
 		if isFile {
 			files = append(files, cur.fullPath('.', trieNodes[:ncindex]))
 			isFiles = append(isFiles, isFile)
@@ -897,6 +928,8 @@ func (ti *trieIndex) query(expr string, limit int, expand func(globs []string) (
 		curm.pop(len(cur.c))
 		goto parent
 
+		// calling this procedure means that we are done with current child and moving level up
+		// we are supposed to check next child of current parent next
 	parent:
 		// use exact for fast exit
 		nindex[ncindex] = 0
@@ -918,7 +951,7 @@ func (ti *trieIndex) query(expr string, limit int, expand func(globs []string) (
 		continue
 	}
 
-	return files, isFiles, nodes, nil
+	return files, isFiles, nodes, lookups, nil
 }
 
 // note: tn might be a root or file node, which has a nil c
@@ -1503,7 +1536,7 @@ func (ti *trieIndex) countNodes() (count, files, dirs, onec, onefc, onedc int, c
 	return
 }
 
-func (listener *CarbonserverListener) expandGlobsTrie(query string) ([]string, []bool, []*trieNode, error) {
+func (listener *CarbonserverListener) expandGlobsTrie(query string) ([]string, []bool, []*trieNode, uint64, error) {
 	query = strings.ReplaceAll(query, ".", "/")
 	globs := []string{query}
 
@@ -1523,7 +1556,7 @@ func (listener *CarbonserverListener) expandGlobsTrie(query string) ([]string, [
 		var err error
 		globs, err = listener.expandGlobBraces(globs)
 		if err != nil {
-			return nil, nil, nil, err
+			return nil, nil, nil, 0, err
 		}
 	}
 
@@ -1531,21 +1564,23 @@ func (listener *CarbonserverListener) expandGlobsTrie(query string) ([]string, [
 	var files []string
 	var leafs []bool
 	var nodes []*trieNode
+	var lookups uint64
 
 	for _, g := range globs {
-		f, l, n, err := fidx.trieIdx.query(g, listener.maxMetricsGlobbed-len(files), listener.expandGlobBraces)
+		f, l, n, lk, err := fidx.trieIdx.query(g, listener.maxMetricsGlobbed-len(files), listener.expandGlobBraces)
 		if err != nil {
-			return nil, nil, nil, err
+			return nil, nil, nil, lookups, err
 		}
 		files = append(files, f...)
 		leafs = append(leafs, l...)
 		nodes = append(nodes, n...)
+		lookups += lk
 	}
 	// set node as viewed
 	for _, node := range nodes {
 		node.incrementReadHitsMetric()
 	}
-	return files, leafs, nodes, nil
+	return files, leafs, nodes, lookups, nil
 }
 
 type QuotaDroppingPolicy int8
@@ -1816,7 +1851,7 @@ func (ti *trieIndex) applyQuotas(resetFrequency time.Duration, quotas ...*Quota)
 			continue
 		}
 
-		paths, _, nodes, err := ti.query(strings.ReplaceAll(quota.Pattern, ".", "/"), 1<<31-1, nil)
+		paths, _, nodes, _, err := ti.query(strings.ReplaceAll(quota.Pattern, ".", "/"), 1<<31-1, nil)
 		if err != nil {
 			return nil, err
 		}

--- a/carbonserver/trie.go
+++ b/carbonserver/trie.go
@@ -754,11 +754,10 @@ func (ti *trieIndex) newDir() *trieNode {
 // TODO: add some defensive logics agains bad queries?
 // depth first search
 // TODO: refactor to make the function more readable. Some ideas:
-// - to isolate Depth first search in separate class
-// - probably we can optimize the length of existed arrays. It uses tree depth + 7, where tree depth is the longest path in the tree in characters
-//   but we should be able to calculate max required depth based on expr, we don't have to look into deeper levels than expr's depth unless there is some unknown corner case exist
-// - get rid of 'goto', since it adds complexions
-//
+//   - to isolate Depth first search in separate class
+//   - probably we can optimize the length of existed arrays. It uses tree depth + 7, where tree depth is the longest path in the tree in characters
+//     but we should be able to calculate max required depth based on expr, we don't have to look into deeper levels than expr's depth unless there is some unknown corner case exist
+//   - get rid of 'goto', since it adds complexions
 func (ti *trieIndex) query(expr string, limit int, expand func(globs []string) ([]string, error)) (files []string, isFiles []bool, nodes []*trieNode, its uint32, err error) {
 	expr = strings.TrimSpace(expr)
 	if expr == "" {

--- a/carbonserver/trie.go
+++ b/carbonserver/trie.go
@@ -758,7 +758,7 @@ func (ti *trieIndex) newDir() *trieNode {
 //   but we should be able to calculate max required depth based on expr, we don't have to look into deeper levels than expr's depth unless there is some unknown corner case exist
 // - get rid of 'goto', since it adds complexions
 //
-func (ti *trieIndex) query(expr string, limit int, expand func(globs []string) ([]string, error)) (files []string, isFiles []bool, nodes []*trieNode, its uint64, err error) {
+func (ti *trieIndex) query(expr string, limit int, expand func(globs []string) ([]string, error)) (files []string, isFiles []bool, nodes []*trieNode, its uint32, err error) {
 	expr = strings.TrimSpace(expr)
 	if expr == "" {
 		expr = "*"
@@ -771,7 +771,7 @@ func (ti *trieIndex) query(expr string, limit int, expand func(globs []string) (
 	// to test if it works properly
 	var exact bool
 	// complexity of query
-	var lookups uint64
+	var lookups uint32
 	for _, node := range strings.Split(expr, "/") {
 		if node == "" {
 			continue
@@ -800,7 +800,7 @@ func (ti *trieIndex) query(expr string, limit int, expand func(globs []string) (
 	var trieNodes = make([]*trieNode, depth)
 	// each item contains an array of all children for every trieNode in current looking path
 	var childrensStack = make([][]*trieNode, depth)
-	//current searching depth
+	// current searching depth
 	var ncindex int
 	// index of needed matcher
 	var mindex int
@@ -1536,7 +1536,7 @@ func (ti *trieIndex) countNodes() (count, files, dirs, onec, onefc, onedc int, c
 	return
 }
 
-func (listener *CarbonserverListener) expandGlobsTrie(query string) ([]string, []bool, []*trieNode, uint64, error) {
+func (listener *CarbonserverListener) expandGlobsTrie(query string) ([]string, []bool, []*trieNode, uint32, error) {
 	query = strings.ReplaceAll(query, ".", "/")
 	globs := []string{query}
 
@@ -1564,7 +1564,7 @@ func (listener *CarbonserverListener) expandGlobsTrie(query string) ([]string, [
 	var files []string
 	var leafs []bool
 	var nodes []*trieNode
-	var lookups uint64
+	var lookups uint32
 
 	for _, g := range globs {
 		f, l, n, lk, err := fidx.trieIdx.query(g, listener.maxMetricsGlobbed-len(files), listener.expandGlobBraces)

--- a/carbonserver/trie_test.go
+++ b/carbonserver/trie_test.go
@@ -745,7 +745,7 @@ func TestTrieIndex(t *testing.T) {
 func TestTrieEdgeCases(t *testing.T) {
 	var trie = newTrie(".wsp", nil)
 
-	_, _, _, err := trie.query("[\xff\xff-\xff", 1000, func([]string) ([]string, error) { return nil, nil })
+	_, _, _, _, err := trie.query("[\xff\xff-\xff", 1000, func([]string) ([]string, error) { return nil, nil })
 	if err == nil || err.Error() != "glob: range overflow" {
 		t.Errorf("trie should return an range overflow error")
 	}
@@ -775,7 +775,7 @@ func TestTrieQueryOpts(t *testing.T) {
 		"sys.app.host-02.cpu.system",
 	}
 
-	files, _, nodes, err := trieIndex.query("sys/app/host-0{1,2}", 1000, nil)
+	files, _, nodes, _, err := trieIndex.query("sys/app/host-0{1,2}", 1000, nil)
 	if err != nil {
 		t.Error(err)
 	}
@@ -837,7 +837,7 @@ func TestTrieConcurrentReadWrite(t *testing.T) {
 		// case <-filec:
 		default:
 			// skipcq: GSC-G404
-			files, _, _, err := trieIndex.query(fmt.Sprintf("level-0-%d/level-1-%d/level-2-%d*", rand.Intn(factor), rand.Intn(factor), rand.Intn(factor)), int(math.MaxInt64), nil)
+			files, _, _, _, err := trieIndex.query(fmt.Sprintf("level-0-%d/level-1-%d/level-2-%d*", rand.Intn(factor), rand.Intn(factor), rand.Intn(factor)), int(math.MaxInt64), nil)
 			if err != nil {
 				panic(err)
 			}


### PR DESCRIPTION
A new field "lookups" is added into access logs for find requests. It is a count of loops of DFS in trie:query function.
The purpose is to have more information in access logs, it might help to investigate low latencies of find requests