### PR TITLE
Factor for physical size for sparse mode. For sparse mode I added config variable which applies to logical size…

### DIFF
--- a/carbon/config.go
+++ b/carbon/config.go
@@ -54,19 +54,20 @@ type commonConfig struct {
 }
 
 type whisperConfig struct {
-	DataDir                 string `toml:"data-dir"`
-	SchemasFilename         string `toml:"schemas-file"`
-	AggregationFilename     string `toml:"aggregation-file"`
-	QuotasFilename          string `toml:"quotas-file"`
-	Workers                 int    `toml:"workers"`
-	MaxUpdatesPerSecond     int    `toml:"max-updates-per-second"`
-	MaxCreatesPerSecond     int    `toml:"max-creates-per-second"`
-	HardMaxCreatesPerSecond bool   `toml:"hard-max-creates-per-second"`
-	Sparse                  bool   `toml:"sparse-create"`
-	FLock                   bool   `toml:"flock"`
-	Compressed              bool   `toml:"compressed"`
-	Enabled                 bool   `toml:"enabled"`
-	HashFilenames           bool   `toml:"hash-filenames"`
+	DataDir                 string  `toml:"data-dir"`
+	SchemasFilename         string  `toml:"schemas-file"`
+	AggregationFilename     string  `toml:"aggregation-file"`
+	QuotasFilename          string  `toml:"quotas-file"`
+	Workers                 int     `toml:"workers"`
+	MaxUpdatesPerSecond     int     `toml:"max-updates-per-second"`
+	MaxCreatesPerSecond     int     `toml:"max-creates-per-second"`
+	HardMaxCreatesPerSecond bool    `toml:"hard-max-creates-per-second"`
+	Sparse                  bool    `toml:"sparse-create"`
+	PhysicalSizeFactor      float32 `toml:"physical-size-factor"`
+	FLock                   bool    `toml:"flock"`
+	Compressed              bool    `toml:"compressed"`
+	Enabled                 bool    `toml:"enabled"`
+	HashFilenames           bool    `toml:"hash-filenames"`
 	Schemas                 persister.WhisperSchemas
 	Aggregation             *persister.WhisperAggregation
 	Quotas                  persister.WhisperQuotas
@@ -226,6 +227,7 @@ func NewConfig() *Config {
 			Enabled:             true,
 			Workers:             1,
 			Sparse:              false,
+			PhysicalSizeFactor:  0.75,
 			FLock:               false,
 			HashFilenames:       true,
 

--- a/carbonserver/carbonserver.go
+++ b/carbonserver/carbonserver.go
@@ -276,7 +276,7 @@ type CarbonserverListener struct {
 	db *leveldb.DB
 
 	quotas                    []*Quota
-	estimateSize              func(metric string) (size, dataPoints int64)
+	estimateSize              func(metric string) (logicalSize, physicalSize, dataPoints int64)
 	quotaAndUsageMetrics      chan []points.Points
 	quotaUsageReportFrequency time.Duration
 
@@ -583,7 +583,7 @@ func (listener *CarbonserverListener) SetInternalStatsDir(dbPath string) {
 func (listener *CarbonserverListener) SetPercentiles(percentiles []int) {
 	listener.percentiles = percentiles
 }
-func (listener *CarbonserverListener) SetEstimateSize(f func(metric string) (size, dataPoints int64)) {
+func (listener *CarbonserverListener) SetEstimateSize(f func(metric string) (logicalSize, physicalSize, dataPoints int64)) {
 	listener.estimateSize = f
 }
 func (listener *CarbonserverListener) SetQuotas(quotas []*Quota) {
@@ -1037,7 +1037,7 @@ func (listener *CarbonserverListener) updateFileList(dir string, cacheMetricName
 					if listener.estimateSize != nil {
 						m := strings.ReplaceAll(trimmedName, "/", ".")
 						m = m[1 : len(m)-4]
-						_, dataPoints = listener.estimateSize(m)
+						_, _, dataPoints = listener.estimateSize(m)
 					}
 					logicalSize = info.Size()
 					physicalSize = logicalSize

--- a/carbonserver/trie_test.go
+++ b/carbonserver/trie_test.go
@@ -1295,8 +1295,8 @@ func TestTrieQuotaGeneral(t *testing.T) {
 		t.Run(fmt.Sprintf("case_%d", i), func(t *testing.T) {
 			tindex := newTrie(
 				".wsp",
-				func(metric string) (size, dataPoints int64) {
-					return 12 * 1024, 1024
+				func(metric string) (logicalSize, physicalSize, dataPoints int64) {
+					return 12 * 1024, 12 * 1024, 1024
 				},
 			)
 
@@ -1346,8 +1346,8 @@ func stringifyQuotaPoints(ps []points.Points) string {
 func TestTrieQuotaThroughput(t *testing.T) {
 	tindex := newTrie(
 		".wsp",
-		func(metric string) (size, dataPoints int64) {
-			return 12 * 1024, 1024
+		func(metric string) (logicalSize, physicalSize, dataPoints int64) {
+			return 12 * 1024, 12 * 1024, 1024
 		},
 	)
 
@@ -1485,8 +1485,8 @@ func TestTrieReadMetric(t *testing.T) {
 func TestTrieQuotaThroughputWithDelayedReset(t *testing.T) {
 	tindex := newTrie(
 		".wsp",
-		func(metric string) (size, dataPoints int64) {
-			return 12 * 1024, 1024
+		func(metric string) (logicalSize, physicalSize, dataPoints int64) {
+			return 12 * 1024, 12 * 1024, 1024
 		},
 	)
 
@@ -1578,8 +1578,8 @@ func TestTrieQuotaThroughputWithDelayedReset(t *testing.T) {
 func TestTrieQuotaConcurrentApplyAndEnforce(t *testing.T) {
 	tindex := newTrie(
 		".wsp",
-		func(metric string) (size, dataPoints int64) {
-			return 12 * 1024, 1024
+		func(metric string) (logicalSize, physicalSize, dataPoints int64) {
+			return 12 * 1024, 12 * 1024, 1024
 		},
 	)
 
@@ -1632,8 +1632,8 @@ func TestTrieQuotaConcurrentApplyAndEnforce(t *testing.T) {
 func TestTrieQuotaWithProperHierarchicalThroughputEnforcement(t *testing.T) {
 	tindex := newTrie(
 		".wsp",
-		func(metric string) (size, dataPoints int64) {
-			return 12 * 1024, 1024
+		func(metric string) (logicalSize, physicalSize, dataPoints int64) {
+			return 12 * 1024, 12 * 1024, 1024
 		},
 	)
 


### PR DESCRIPTION
Currently, when a new metrics are sent to go-carbon, if physical size quota is enabled, go-carbon would use its logical size as physical size (based on its matching schema). But with sparse mode, it means that the dynamically generated physical size is much larger than its actual disk size. This might causes unnecessary throttling. 
 To solve this problem I added factor multiplier PhysicalSizeFactor (0.75 by default) which allows to reduce physical in case if sparse mode is on:
metric_physical_size = PhysicalSizeFactor * metric_logical_size
