### PR TITLE
Fix carbonserver Stat() from resetting the value of max-inflight-requests to zero

### DIFF
--- a/carbonserver/carbonserver.go
+++ b/carbonserver/carbonserver.go
@@ -1500,7 +1500,7 @@ func (listener *CarbonserverListener) Stat(send helper.StatCallback) {
 	sender("find_cache_miss", &listener.metrics.FindCacheMiss, send)
 
 	sender("inflight_requests_count", &listener.metrics.InflightRequests, send)
-	sender("inflight_requests_limit", &listener.MaxInflightRequests, send)
+	senderRaw("inflight_requests_limit", &listener.MaxInflightRequests, send)
 	sender("rejected_too_many_requests", &listener.metrics.RejectedTooManyRequests, send)
 
 	if listener.concurrentIndex {


### PR DESCRIPTION
:wave: I am not sure the best process for contributing fixes, but figured I would open a PR instead of a github issue since the fix here is a 1 line change.

It appears that the `max-inflight-requests` configuration is broken. The configuration gets set correctly, but the first time the stats collector runs it gets unset. This confused me when verifying how this configuration option behaves during some load testing to releasing this configuration to our production go-carbon deployment.

(my testing was done using the v0.16.2 tag, however the issue appears to still be in the HEAD of `master` as well).

This can be observed by adding a logger call right before https://github.com/go-graphite/go-carbon/blob/v0.16.2/carbonserver/carbonserver.go#L1561 to print the value of `listener.MaxInflightRequests`. When running go-carbon built with that extra logger, and then performing a request once every 2-3 seconds, we can see the value of `listener.MaxInflightRequests` reset to zero after the stats collector runs


```
ubuntu@tp135859-ts-carbon-vpc-04620a6a2f1c3a447:~$ sudo service go-carbon stop && sudo truncate -s 0 /var/log/go-carbon/go-carbon.log && sudo service go-carbon start && tail -f /var/log/go-carbon/go-carbon.log
[2022-09-15T17:16:46.720Z] INFO [carbonserver] starting carbonserver {"listen": "0.0.0.0:8080", "whisperData": "/var/lib/graphite/graphite/whisper", "maxGlobs": 100, "scanFrequency": "5m0s"}
[2022-09-15T17:16:46.721Z] INFO [main] started {}
[2022-09-15T17:16:46.721Z] ERROR [restore] readdir failed {"dir": "/var/lib/graphite/go-carbon-dump/", "error": "open /var/lib/graphite/go-carbon-dump/: no such file or directory"}
[2022-09-15T17:16:46.721Z] INFO [restore] restore finished {"dir": "/var/lib/graphite/go-carbon-dump/", "runtime": 0.000288779}
[2022-09-15T17:16:48.639Z] INFO [carbonserver] file list updated {"handler": "fileListUpdated", "trie_depth": 257, "longest_metric": "service_is_carbon-relay-ng/instance_is_tp135859-ts-carbon-relay-ng-vpc-006ce918040ee96e7/mtype_is_count/unit_is_Metric/dest_is_allmetrics_tp135859-ts-carbon-vpc-dev-10_servers_clovesoftware-dev_com_2004/what_is_durationFlush/type_is_overflow/orig_unit_is_ns", "trie_count_nodes_time": 0.11261432, "file_scan_runtime": 1.806292707, "indexing_runtime": 0.11261871, "rdtime_update_runtime": 0.000000136, "cache_index_runtime": 0.000000184, "total_runtime": 1.918913754, "Files": 1762740, "index_size": 3593625, "pruned_trigrams": 0, "cache_metric_len_before": 0, "cache_metric_len_after": 0, "metrics_known": 1695625, "index_type": "trie", "read_from_cache": true}
[2022-09-15T17:16:48.639Z] INFO [carbonserver] file list updated with cache, starting a new scan immediately {}
[2022-09-15T17:16:50.413Z] ERROR [access] JMEICHLE we have this value listener.MaxInflightRequest=1 and inflights=1 {"handler": "rate_limit", "url": "/render/?target=carbon.*.*.*.*&from=1663260410&until=1663262210", "peer": "127.0.0.1:49522"}
[2022-09-15T17:16:52.422Z] INFO [access] fetch served {"handler": "render", "url": "/render/?target=carbon.*.*.*.*&from=1663260410&until=1663262210", "peer": "127.0.0.1:49522", "targets": ["carbon.*.*.*.*"], "format": "json", "runtime_seconds": 0.008247747, "query_cache_enabled": true, "from_cache": false, "metrics_fetched": 164, "values_fetched": 19680, "memory_used_bytes": 193964, "http_code": 200}
[2022-09-15T17:16:52.927Z] ERROR [access] JMEICHLE we have this value listener.MaxInflightRequest=1 and inflights=1 {"handler": "rate_limit", "url": "/render/?target=carbon.*.*.*.*&from=1663260412&until=1663262212", "peer": "127.0.0.1:49524"}
[2022-09-15T17:16:54.935Z] INFO [access] fetch served {"handler": "render", "url": "/render/?target=carbon.*.*.*.*&from=1663260412&until=1663262212", "peer": "127.0.0.1:49524", "targets": ["carbon.*.*.*.*"], "format": "json", "runtime_seconds": 0.008166506, "query_cache_enabled": true, "from_cache": false, "metrics_fetched": 164, "values_fetched": 19680, "memory_used_bytes": 193964, "http_code": 200}
[2022-09-15T17:16:55.440Z] ERROR [access] JMEICHLE we have this value listener.MaxInflightRequest=1 and inflights=1 {"handler": "rate_limit", "url": "/render/?target=carbon.*.*.*.*&from=1663260415&until=1663262215", "peer": "127.0.0.1:49526"}
[2022-09-15T17:16:57.449Z] INFO [access] fetch served {"handler": "render", "url": "/render/?target=carbon.*.*.*.*&from=1663260415&until=1663262215", "peer": "127.0.0.1:49526", "targets": ["carbon.*.*.*.*"], "format": "json", "runtime_seconds": 0.008623501, "query_cache_enabled": true, "from_cache": false, "metrics_fetched": 164, "values_fetched": 19680, "memory_used_bytes": 193964, "http_code": 200}
[2022-09-15T17:16:57.954Z] ERROR [access] JMEICHLE we have this value listener.MaxInflightRequest=1 and inflights=1 {"handler": "rate_limit", "url": "/render/?target=carbon.*.*.*.*&from=1663260417&until=1663262217", "peer": "127.0.0.1:49528"}
[2022-09-15T17:16:58.466Z] INFO [carbonserver] file list updated {"handler": "fileListUpdated", "trie_depth": 257, "longest_metric": "service_is_carbon-relay-ng/instance_is_tp135859-ts-carbon-relay-ng-vpc-006ce918040ee96e7/mtype_is_count/unit_is_Metric/dest_is_allmetrics_tp135859-ts-carbon-vpc-dev-10_servers_clovesoftware-dev_com_2004/what_is_durationFlush/type_is_overflow/orig_unit_is_ns", "trie_count_nodes_time": 0.152031224, "file_scan_runtime": 9.674462948, "indexing_runtime": 0.152033365, "rdtime_update_runtime": 0.00000012, "cache_index_runtime": 0.000000176, "total_runtime": 9.82649883, "Files": 1762741, "index_size": 3591177, "pruned_trigrams": 0, "cache_metric_len_before": 0, "cache_metric_len_after": 0, "metrics_known": 1695625, "index_type": "trie", "read_from_cache": false}
[2022-09-15T17:16:59.962Z] INFO [access] fetch served {"handler": "render", "url": "/render/?target=carbon.*.*.*.*&from=1663260417&until=1663262217", "peer": "127.0.0.1:49528", "targets": ["carbon.*.*.*.*"], "format": "json", "runtime_seconds": 0.006977571, "query_cache_enabled": true, "from_cache": false, "metrics_fetched": 164, "values_fetched": 19680, "memory_used_bytes": 193964, "http_code": 200}
[2022-09-15T17:17:00.466Z] ERROR [access] JMEICHLE we have this value listener.MaxInflightRequest=1 and inflights=1 {"handler": "rate_limit", "url": "/render/?target=carbon.*.*.*.*&from=1663260420&until=1663262220", "peer": "127.0.0.1:49530"}
[2022-09-15T17:17:01.721Z] INFO [stat] collect {"endpoint": "local", "metric": "carbon.agents.tp135859-ts-carbon-vpc-04620a6a2f1c3a447.runtime.GOMAXPROCS", "value": 14}
[2022-09-15T17:17:01.721Z] INFO [stat] collect {"endpoint": "local", "metric": "carbon.agents.tp135859-ts-carbon-vpc-04620a6a2f1c3a447.runtime.NumGoroutine", "value": 30}
[2022-09-15T17:17:01.721Z] INFO [stat] collect {"endpoint": "local", "metric": "carbon.agents.tp135859-ts-carbon-vpc-04620a6a2f1c3a447.cache.size", "value": 0}
[2022-09-15T17:17:01.721Z] INFO [stat] collect {"endpoint": "local", "metric": "carbon.agents.tp135859-ts-carbon-vpc-04620a6a2f1c3a447.cache.metrics", "value": 0}
[2022-09-15T17:17:01.721Z] INFO [stat] collect {"endpoint": "local", "metric": "carbon.agents.tp135859-ts-carbon-vpc-04620a6a2f1c3a447.cache.maxSize", "value": 100000000}
[2022-09-15T17:17:01.721Z] INFO [stat] collect {"endpoint": "local", "metric": "carbon.agents.tp135859-ts-carbon-vpc-04620a6a2f1c3a447.cache.notConfirmed", "value": 4096}
[2022-09-15T17:17:01.721Z] INFO [stat] collect {"endpoint": "local", "metric": "carbon.agents.tp135859-ts-carbon-vpc-04620a6a2f1c3a447.cache.queries", "value": 656}
[2022-09-15T17:17:01.721Z] INFO [stat] collect {"endpoint": "local", "metric": "carbon.agents.tp135859-ts-carbon-vpc-04620a6a2f1c3a447.cache.tagsNormalizeErrors", "value": 0}
[2022-09-15T17:17:01.721Z] INFO [stat] collect {"endpoint": "local", "metric": "carbon.agents.tp135859-ts-carbon-vpc-04620a6a2f1c3a447.cache.overflow", "value": 0}
[2022-09-15T17:17:01.721Z] INFO [stat] collect {"endpoint": "local", "metric": "carbon.agents.tp135859-ts-carbon-vpc-04620a6a2f1c3a447.cache.queueBuildCount", "value": 150}
[2022-09-15T17:17:01.721Z] INFO [stat] collect {"endpoint": "local", "metric": "carbon.agents.tp135859-ts-carbon-vpc-04620a6a2f1c3a447.cache.queueBuildTimeMs", "value": 0}
[2022-09-15T17:17:01.721Z] INFO [stat] collect {"endpoint": "local", "metric": "carbon.agents.tp135859-ts-carbon-vpc-04620a6a2f1c3a447.cache.queueWriteoutTime", "value": 0}
[2022-09-15T17:17:01.721Z] INFO [stat] collect {"endpoint": "local", "metric": "carbon.agents.tp135859-ts-carbon-vpc-04620a6a2f1c3a447.cache.droppedRealtimeIndex", "value": 0}
[2022-09-15T17:17:01.722Z] INFO [stat] collect {"endpoint": "local", "metric": "carbon.agents.tp135859-ts-carbon-vpc-04620a6a2f1c3a447.carbonserver.render_requests", "value": 4}
[2022-09-15T17:17:01.722Z] INFO [stat] collect {"endpoint": "local", "metric": "carbon.agents.tp135859-ts-carbon-vpc-04620a6a2f1c3a447.carbonserver.render_errors", "value": 0}
[2022-09-15T17:17:01.722Z] INFO [stat] collect {"endpoint": "local", "metric": "carbon.agents.tp135859-ts-carbon-vpc-04620a6a2f1c3a447.carbonserver.notfound", "value": 0}
[2022-09-15T17:17:01.722Z] INFO [stat] collect {"endpoint": "local", "metric": "carbon.agents.tp135859-ts-carbon-vpc-04620a6a2f1c3a447.carbonserver.find_requests", "value": 0}
[2022-09-15T17:17:01.722Z] INFO [stat] collect {"endpoint": "local", "metric": "carbon.agents.tp135859-ts-carbon-vpc-04620a6a2f1c3a447.carbonserver.find_errors", "value": 0}
[2022-09-15T17:17:01.722Z] INFO [stat] collect {"endpoint": "local", "metric": "carbon.agents.tp135859-ts-carbon-vpc-04620a6a2f1c3a447.carbonserver.find_zero", "value": 0}
[2022-09-15T17:17:01.722Z] INFO [stat] collect {"endpoint": "local", "metric": "carbon.agents.tp135859-ts-carbon-vpc-04620a6a2f1c3a447.carbonserver.list_requests", "value": 0}
[2022-09-15T17:17:01.722Z] INFO [stat] collect {"endpoint": "local", "metric": "carbon.agents.tp135859-ts-carbon-vpc-04620a6a2f1c3a447.carbonserver.list_errors", "value": 0}
[2022-09-15T17:17:01.722Z] INFO [stat] collect {"endpoint": "local", "metric": "carbon.agents.tp135859-ts-carbon-vpc-04620a6a2f1c3a447.carbonserver.details_requests", "value": 0}
[2022-09-15T17:17:01.722Z] INFO [stat] collect {"endpoint": "local", "metric": "carbon.agents.tp135859-ts-carbon-vpc-04620a6a2f1c3a447.carbonserver.details_errors", "value": 0}
[2022-09-15T17:17:01.722Z] INFO [stat] collect {"endpoint": "local", "metric": "carbon.agents.tp135859-ts-carbon-vpc-04620a6a2f1c3a447.carbonserver.cache_hit", "value": 0}
[2022-09-15T17:17:01.722Z] INFO [stat] collect {"endpoint": "local", "metric": "carbon.agents.tp135859-ts-carbon-vpc-04620a6a2f1c3a447.carbonserver.cache_miss", "value": 0}
[2022-09-15T17:17:01.722Z] INFO [stat] collect {"endpoint": "local", "metric": "carbon.agents.tp135859-ts-carbon-vpc-04620a6a2f1c3a447.carbonserver.cache_work_time_ns", "value": 0}
[2022-09-15T17:17:01.722Z] INFO [stat] collect {"endpoint": "local", "metric": "carbon.agents.tp135859-ts-carbon-vpc-04620a6a2f1c3a447.carbonserver.cache_wait_time_fetch_ns", "value": 217605}
[2022-09-15T17:17:01.722Z] INFO [stat] collect {"endpoint": "local", "metric": "carbon.agents.tp135859-ts-carbon-vpc-04620a6a2f1c3a447.carbonserver.cache_requests", "value": 0}
[2022-09-15T17:17:01.722Z] INFO [stat] collect {"endpoint": "local", "metric": "carbon.agents.tp135859-ts-carbon-vpc-04620a6a2f1c3a447.carbonserver.disk_wait_time_ns", "value": 4157035}
[2022-09-15T17:17:01.722Z] INFO [stat] collect {"endpoint": "local", "metric": "carbon.agents.tp135859-ts-carbon-vpc-04620a6a2f1c3a447.carbonserver.disk_requests", "value": 656}
[2022-09-15T17:17:01.722Z] INFO [stat] collect {"endpoint": "local", "metric": "carbon.agents.tp135859-ts-carbon-vpc-04620a6a2f1c3a447.carbonserver.points_returned", "value": 78720}
[2022-09-15T17:17:01.722Z] INFO [stat] collect {"endpoint": "local", "metric": "carbon.agents.tp135859-ts-carbon-vpc-04620a6a2f1c3a447.carbonserver.metrics_returned", "value": 656}
[2022-09-15T17:17:01.722Z] INFO [stat] collect {"endpoint": "local", "metric": "carbon.agents.tp135859-ts-carbon-vpc-04620a6a2f1c3a447.carbonserver.metrics_found", "value": 0}
[2022-09-15T17:17:01.722Z] INFO [stat] collect {"endpoint": "local", "metric": "carbon.agents.tp135859-ts-carbon-vpc-04620a6a2f1c3a447.carbonserver.fetch_size_bytes", "value": 775856}
[2022-09-15T17:17:01.722Z] INFO [stat] collect {"endpoint": "local", "metric": "carbon.agents.tp135859-ts-carbon-vpc-04620a6a2f1c3a447.carbonserver.metrics_known", "value": 1695625}
[2022-09-15T17:17:01.722Z] INFO [stat] collect {"endpoint": "local", "metric": "carbon.agents.tp135859-ts-carbon-vpc-04620a6a2f1c3a447.carbonserver.index_build_time_ns", "value": 264652075}
[2022-09-15T17:17:01.722Z] INFO [stat] collect {"endpoint": "local", "metric": "carbon.agents.tp135859-ts-carbon-vpc-04620a6a2f1c3a447.carbonserver.file_scan_time_ns", "value": 11480755655}
[2022-09-15T17:17:01.722Z] INFO [stat] collect {"endpoint": "local", "metric": "carbon.agents.tp135859-ts-carbon-vpc-04620a6a2f1c3a447.carbonserver.query_cache_hit", "value": 0}
[2022-09-15T17:17:01.722Z] INFO [stat] collect {"endpoint": "local", "metric": "carbon.agents.tp135859-ts-carbon-vpc-04620a6a2f1c3a447.carbonserver.query_cache_miss", "value": 4}
[2022-09-15T17:17:01.722Z] INFO [stat] collect {"endpoint": "local", "metric": "carbon.agents.tp135859-ts-carbon-vpc-04620a6a2f1c3a447.carbonserver.find_cache_hit", "value": 0}
[2022-09-15T17:17:01.722Z] INFO [stat] collect {"endpoint": "local", "metric": "carbon.agents.tp135859-ts-carbon-vpc-04620a6a2f1c3a447.carbonserver.find_cache_miss", "value": 0}
[2022-09-15T17:17:01.722Z] INFO [stat] collect {"endpoint": "local", "metric": "carbon.agents.tp135859-ts-carbon-vpc-04620a6a2f1c3a447.carbonserver.inflight_requests_count", "value": 1}
[2022-09-15T17:17:01.722Z] INFO [stat] collect {"endpoint": "local", "metric": "carbon.agents.tp135859-ts-carbon-vpc-04620a6a2f1c3a447.carbonserver.inflight_requests_limit", "value": 1}
[2022-09-15T17:17:01.722Z] INFO [stat] collect {"endpoint": "local", "metric": "carbon.agents.tp135859-ts-carbon-vpc-04620a6a2f1c3a447.carbonserver.rejected_too_many_requests", "value": 0}
[2022-09-15T17:17:01.722Z] INFO [stat] collect {"endpoint": "local", "metric": "carbon.agents.tp135859-ts-carbon-vpc-04620a6a2f1c3a447.carbonserver.alloc", "value": 775414352}
[2022-09-15T17:17:01.722Z] INFO [stat] collect {"endpoint": "local", "metric": "carbon.agents.tp135859-ts-carbon-vpc-04620a6a2f1c3a447.carbonserver.total_alloc", "value": 2196533440}
[2022-09-15T17:17:01.722Z] INFO [stat] collect {"endpoint": "local", "metric": "carbon.agents.tp135859-ts-carbon-vpc-04620a6a2f1c3a447.carbonserver.num_gc", "value": 17}
[2022-09-15T17:17:01.722Z] INFO [stat] collect {"endpoint": "local", "metric": "carbon.agents.tp135859-ts-carbon-vpc-04620a6a2f1c3a447.carbonserver.pause_ns", "value": 960293}
[2022-09-15T17:17:01.722Z] INFO [stat] collect {"endpoint": "local", "metric": "carbon.agents.tp135859-ts-carbon-vpc-04620a6a2f1c3a447.carbonserver.request_codes.details.1xx", "value": 0}
[2022-09-15T17:17:01.722Z] INFO [stat] collect {"endpoint": "local", "metric": "carbon.agents.tp135859-ts-carbon-vpc-04620a6a2f1c3a447.carbonserver.request_codes.details.2xx", "value": 0}
[2022-09-15T17:17:01.722Z] INFO [stat] collect {"endpoint": "local", "metric": "carbon.agents.tp135859-ts-carbon-vpc-04620a6a2f1c3a447.carbonserver.request_codes.details.3xx", "value": 0}
[2022-09-15T17:17:01.722Z] INFO [stat] collect {"endpoint": "local", "metric": "carbon.agents.tp135859-ts-carbon-vpc-04620a6a2f1c3a447.carbonserver.request_codes.details.4xx", "value": 0}
[2022-09-15T17:17:01.722Z] INFO [stat] collect {"endpoint": "local", "metric": "carbon.agents.tp135859-ts-carbon-vpc-04620a6a2f1c3a447.carbonserver.request_codes.details.5xx", "value": 0}
[2022-09-15T17:17:01.722Z] INFO [stat] collect {"endpoint": "local", "metric": "carbon.agents.tp135859-ts-carbon-vpc-04620a6a2f1c3a447.carbonserver.request_codes.info.1xx", "value": 0}
[2022-09-15T17:17:01.722Z] INFO [stat] collect {"endpoint": "local", "metric": "carbon.agents.tp135859-ts-carbon-vpc-04620a6a2f1c3a447.carbonserver.request_codes.info.2xx", "value": 0}
[2022-09-15T17:17:01.722Z] INFO [stat] collect {"endpoint": "local", "metric": "carbon.agents.tp135859-ts-carbon-vpc-04620a6a2f1c3a447.carbonserver.request_codes.info.3xx", "value": 0}
[2022-09-15T17:17:01.722Z] INFO [stat] collect {"endpoint": "local", "metric": "carbon.agents.tp135859-ts-carbon-vpc-04620a6a2f1c3a447.carbonserver.request_codes.info.4xx", "value": 0}
[2022-09-15T17:17:01.722Z] INFO [stat] collect {"endpoint": "local", "metric": "carbon.agents.tp135859-ts-carbon-vpc-04620a6a2f1c3a447.carbonserver.request_codes.info.5xx", "value": 0}
[2022-09-15T17:17:01.722Z] INFO [stat] collect {"endpoint": "local", "metric": "carbon.agents.tp135859-ts-carbon-vpc-04620a6a2f1c3a447.carbonserver.request_codes.capabilities.1xx", "value": 0}
[2022-09-15T17:17:01.722Z] INFO [stat] collect {"endpoint": "local", "metric": "carbon.agents.tp135859-ts-carbon-vpc-04620a6a2f1c3a447.carbonserver.request_codes.capabilities.2xx", "value": 0}
[2022-09-15T17:17:01.722Z] INFO [stat] collect {"endpoint": "local", "metric": "carbon.agents.tp135859-ts-carbon-vpc-04620a6a2f1c3a447.carbonserver.request_codes.capabilities.3xx", "value": 0}
[2022-09-15T17:17:01.722Z] INFO [stat] collect {"endpoint": "local", "metric": "carbon.agents.tp135859-ts-carbon-vpc-04620a6a2f1c3a447.carbonserver.request_codes.capabilities.4xx", "value": 0}
[2022-09-15T17:17:01.722Z] INFO [stat] collect {"endpoint": "local", "metric": "carbon.agents.tp135859-ts-carbon-vpc-04620a6a2f1c3a447.carbonserver.request_codes.capabilities.5xx", "value": 0}
[2022-09-15T17:17:01.722Z] INFO [stat] collect {"endpoint": "local", "metric": "carbon.agents.tp135859-ts-carbon-vpc-04620a6a2f1c3a447.carbonserver.request_codes.combined.1xx", "value": 0}
[2022-09-15T17:17:01.722Z] INFO [stat] collect {"endpoint": "local", "metric": "carbon.agents.tp135859-ts-carbon-vpc-04620a6a2f1c3a447.carbonserver.request_codes.combined.2xx", "value": 4}
[2022-09-15T17:17:01.722Z] INFO [stat] collect {"endpoint": "local", "metric": "carbon.agents.tp135859-ts-carbon-vpc-04620a6a2f1c3a447.carbonserver.request_codes.combined.3xx", "value": 0}
[2022-09-15T17:17:01.722Z] INFO [stat] collect {"endpoint": "local", "metric": "carbon.agents.tp135859-ts-carbon-vpc-04620a6a2f1c3a447.carbonserver.request_codes.combined.4xx", "value": 0}
[2022-09-15T17:17:01.722Z] INFO [stat] collect {"endpoint": "local", "metric": "carbon.agents.tp135859-ts-carbon-vpc-04620a6a2f1c3a447.carbonserver.request_codes.combined.5xx", "value": 0}
[2022-09-15T17:17:01.722Z] INFO [stat] collect {"endpoint": "local", "metric": "carbon.agents.tp135859-ts-carbon-vpc-04620a6a2f1c3a447.carbonserver.request_codes.find.1xx", "value": 0}
[2022-09-15T17:17:01.722Z] INFO [stat] collect {"endpoint": "local", "metric": "carbon.agents.tp135859-ts-carbon-vpc-04620a6a2f1c3a447.carbonserver.request_codes.find.2xx", "value": 0}
[2022-09-15T17:17:01.722Z] INFO [stat] collect {"endpoint": "local", "metric": "carbon.agents.tp135859-ts-carbon-vpc-04620a6a2f1c3a447.carbonserver.request_codes.find.3xx", "value": 0}
[2022-09-15T17:17:01.722Z] INFO [stat] collect {"endpoint": "local", "metric": "carbon.agents.tp135859-ts-carbon-vpc-04620a6a2f1c3a447.carbonserver.request_codes.find.4xx", "value": 0}
[2022-09-15T17:17:01.722Z] INFO [stat] collect {"endpoint": "local", "metric": "carbon.agents.tp135859-ts-carbon-vpc-04620a6a2f1c3a447.carbonserver.request_codes.find.5xx", "value": 0}
[2022-09-15T17:17:01.722Z] INFO [stat] collect {"endpoint": "local", "metric": "carbon.agents.tp135859-ts-carbon-vpc-04620a6a2f1c3a447.carbonserver.request_codes.list.1xx", "value": 0}
[2022-09-15T17:17:01.722Z] INFO [stat] collect {"endpoint": "local", "metric": "carbon.agents.tp135859-ts-carbon-vpc-04620a6a2f1c3a447.carbonserver.request_codes.list.2xx", "value": 0}
[2022-09-15T17:17:01.722Z] INFO [stat] collect {"endpoint": "local", "metric": "carbon.agents.tp135859-ts-carbon-vpc-04620a6a2f1c3a447.carbonserver.request_codes.list.3xx", "value": 0}
[2022-09-15T17:17:01.722Z] INFO [stat] collect {"endpoint": "local", "metric": "carbon.agents.tp135859-ts-carbon-vpc-04620a6a2f1c3a447.carbonserver.request_codes.list.4xx", "value": 0}
[2022-09-15T17:17:01.722Z] INFO [stat] collect {"endpoint": "local", "metric": "carbon.agents.tp135859-ts-carbon-vpc-04620a6a2f1c3a447.carbonserver.request_codes.list.5xx", "value": 0}
[2022-09-15T17:17:01.722Z] INFO [stat] collect {"endpoint": "local", "metric": "carbon.agents.tp135859-ts-carbon-vpc-04620a6a2f1c3a447.carbonserver.request_codes.render.1xx", "value": 0}
[2022-09-15T17:17:01.722Z] INFO [stat] collect {"endpoint": "local", "metric": "carbon.agents.tp135859-ts-carbon-vpc-04620a6a2f1c3a447.carbonserver.request_codes.render.2xx", "value": 4}
[2022-09-15T17:17:01.722Z] INFO [stat] collect {"endpoint": "local", "metric": "carbon.agents.tp135859-ts-carbon-vpc-04620a6a2f1c3a447.carbonserver.request_codes.render.3xx", "value": 0}
[2022-09-15T17:17:01.722Z] INFO [stat] collect {"endpoint": "local", "metric": "carbon.agents.tp135859-ts-carbon-vpc-04620a6a2f1c3a447.carbonserver.request_codes.render.4xx", "value": 0}
[2022-09-15T17:17:01.722Z] INFO [stat] collect {"endpoint": "local", "metric": "carbon.agents.tp135859-ts-carbon-vpc-04620a6a2f1c3a447.carbonserver.request_codes.render.5xx", "value": 0}
[2022-09-15T17:17:01.722Z] INFO [stat] collect {"endpoint": "local", "metric": "carbon.agents.tp135859-ts-carbon-vpc-04620a6a2f1c3a447.carbonserver.requests_in_0ms_to_100ms", "value": 0}
[2022-09-15T17:17:01.722Z] INFO [stat] collect {"endpoint": "local", "metric": "carbon.agents.tp135859-ts-carbon-vpc-04620a6a2f1c3a447.carbonserver.requests_in_100ms_to_200ms", "value": 0}
[2022-09-15T17:17:01.722Z] INFO [stat] collect {"endpoint": "local", "metric": "carbon.agents.tp135859-ts-carbon-vpc-04620a6a2f1c3a447.carbonserver.requests_in_200ms_to_300ms", "value": 0}
[2022-09-15T17:17:01.722Z] INFO [stat] collect {"endpoint": "local", "metric": "carbon.agents.tp135859-ts-carbon-vpc-04620a6a2f1c3a447.carbonserver.requests_in_300ms_to_400ms", "value": 4}
[2022-09-15T17:17:01.722Z] INFO [stat] collect {"endpoint": "local", "metric": "carbon.agents.tp135859-ts-carbon-vpc-04620a6a2f1c3a447.carbonserver.requests_in_400ms_to_500ms", "value": 0}
[2022-09-15T17:17:01.722Z] INFO [stat] collect {"endpoint": "local", "metric": "carbon.agents.tp135859-ts-carbon-vpc-04620a6a2f1c3a447.carbonserver.requests_in_500ms_to_600ms", "value": 0}
[2022-09-15T17:17:01.722Z] INFO [stat] collect {"endpoint": "local", "metric": "carbon.agents.tp135859-ts-carbon-vpc-04620a6a2f1c3a447.carbonserver.requests_in_600ms_to_700ms", "value": 0}
[2022-09-15T17:17:01.722Z] INFO [stat] collect {"endpoint": "local", "metric": "carbon.agents.tp135859-ts-carbon-vpc-04620a6a2f1c3a447.carbonserver.requests_in_700ms_to_800ms", "value": 0}
[2022-09-15T17:17:01.722Z] INFO [stat] collect {"endpoint": "local", "metric": "carbon.agents.tp135859-ts-carbon-vpc-04620a6a2f1c3a447.carbonserver.requests_in_800ms_to_900ms", "value": 0}
[2022-09-15T17:17:01.722Z] INFO [stat] collect {"endpoint": "local", "metric": "carbon.agents.tp135859-ts-carbon-vpc-04620a6a2f1c3a447.carbonserver.requests_in_900ms_to_1000ms", "value": 0}
[2022-09-15T17:17:01.722Z] INFO [stat] collect {"endpoint": "local", "metric": "carbon.agents.tp135859-ts-carbon-vpc-04620a6a2f1c3a447.carbonserver.requests_in_1000ms_to_1100ms", "value": 0}
[2022-09-15T17:17:01.722Z] INFO [stat] collect {"endpoint": "local", "metric": "carbon.agents.tp135859-ts-carbon-vpc-04620a6a2f1c3a447.carbonserver.request_time_99th_percentile_ns", "value": 2009209514}
[2022-09-15T17:17:01.722Z] INFO [stat] collect {"endpoint": "local", "metric": "carbon.agents.tp135859-ts-carbon-vpc-04620a6a2f1c3a447.carbonserver.request_time_98th_percentile_ns", "value": 2009209514}
[2022-09-15T17:17:01.722Z] INFO [stat] collect {"endpoint": "local", "metric": "carbon.agents.tp135859-ts-carbon-vpc-04620a6a2f1c3a447.carbonserver.request_time_95th_percentile_ns", "value": 2009209514}
[2022-09-15T17:17:01.722Z] INFO [stat] collect {"endpoint": "local", "metric": "carbon.agents.tp135859-ts-carbon-vpc-04620a6a2f1c3a447.carbonserver.request_time_75th_percentile_ns", "value": 2009209514}
[2022-09-15T17:17:01.722Z] INFO [stat] collect {"endpoint": "local", "metric": "carbon.agents.tp135859-ts-carbon-vpc-04620a6a2f1c3a447.carbonserver.request_time_50th_percentile_ns", "value": 2008374338}
[2022-09-15T17:17:01.722Z] INFO [stat] collect {"endpoint": "local", "metric": "carbon.agents.tp135859-ts-carbon-vpc-04620a6a2f1c3a447.udp.metricsReceived", "value": 0}
[2022-09-15T17:17:01.722Z] INFO [stat] collect {"endpoint": "local", "metric": "carbon.agents.tp135859-ts-carbon-vpc-04620a6a2f1c3a447.udp.errors", "value": 0}
[2022-09-15T17:17:01.722Z] INFO [stat] collect {"endpoint": "local", "metric": "carbon.agents.tp135859-ts-carbon-vpc-04620a6a2f1c3a447.tcp.metricsReceived", "value": 0}
[2022-09-15T17:17:01.722Z] INFO [stat] collect {"endpoint": "local", "metric": "carbon.agents.tp135859-ts-carbon-vpc-04620a6a2f1c3a447.tcp.active", "value": 0}
[2022-09-15T17:17:01.722Z] INFO [stat] collect {"endpoint": "local", "metric": "carbon.agents.tp135859-ts-carbon-vpc-04620a6a2f1c3a447.tcp.errors", "value": 0}
[2022-09-15T17:17:01.722Z] INFO [stat] collect {"endpoint": "local", "metric": "carbon.agents.tp135859-ts-carbon-vpc-04620a6a2f1c3a447.pickle.metricsReceived", "value": 0}
[2022-09-15T17:17:01.722Z] INFO [stat] collect {"endpoint": "local", "metric": "carbon.agents.tp135859-ts-carbon-vpc-04620a6a2f1c3a447.pickle.active", "value": 0}
[2022-09-15T17:17:01.722Z] INFO [stat] collect {"endpoint": "local", "metric": "carbon.agents.tp135859-ts-carbon-vpc-04620a6a2f1c3a447.pickle.errors", "value": 0}
[2022-09-15T17:17:01.722Z] INFO [stat] collect {"endpoint": "local", "metric": "carbon.agents.tp135859-ts-carbon-vpc-04620a6a2f1c3a447.persister.updateOperations", "value": 0}
[2022-09-15T17:17:01.723Z] INFO [stat] collect {"endpoint": "local", "metric": "carbon.agents.tp135859-ts-carbon-vpc-04620a6a2f1c3a447.persister.committedPoints", "value": 0}
[2022-09-15T17:17:01.723Z] INFO [stat] collect {"endpoint": "local", "metric": "carbon.agents.tp135859-ts-carbon-vpc-04620a6a2f1c3a447.persister.pointsPerUpdate", "value": 0}
[2022-09-15T17:17:01.723Z] INFO [stat] collect {"endpoint": "local", "metric": "carbon.agents.tp135859-ts-carbon-vpc-04620a6a2f1c3a447.persister.created", "value": 0}
[2022-09-15T17:17:01.723Z] INFO [stat] collect {"endpoint": "local", "metric": "carbon.agents.tp135859-ts-carbon-vpc-04620a6a2f1c3a447.persister.throttledCreates", "value": 0}
[2022-09-15T17:17:01.723Z] INFO [stat] collect {"endpoint": "local", "metric": "carbon.agents.tp135859-ts-carbon-vpc-04620a6a2f1c3a447.persister.maxCreatesPerSecond", "value": 0}
[2022-09-15T17:17:01.723Z] INFO [stat] collect {"endpoint": "local", "metric": "carbon.agents.tp135859-ts-carbon-vpc-04620a6a2f1c3a447.persister.maxUpdatesPerSecond", "value": 0}
[2022-09-15T17:17:01.723Z] INFO [stat] collect {"endpoint": "local", "metric": "carbon.agents.tp135859-ts-carbon-vpc-04620a6a2f1c3a447.persister.workers", "value": 8}
[2022-09-15T17:17:01.723Z] INFO [stat] collect {"endpoint": "local", "metric": "carbon.agents.tp135859-ts-carbon-vpc-04620a6a2f1c3a447.persister.extended", "value": 0}
[2022-09-15T17:17:02.475Z] INFO [access] fetch served {"handler": "render", "url": "/render/?target=carbon.*.*.*.*&from=1663260420&until=1663262220", "peer": "127.0.0.1:49530", "targets": ["carbon.*.*.*.*"], "format": "json", "runtime_seconds": 0.007492554, "query_cache_enabled": true, "from_cache": false, "metrics_fetched": 164, "values_fetched": 19680, "memory_used_bytes": 193964, "http_code": 200}
[2022-09-15T17:17:02.979Z] ERROR [access] JMEICHLE we have this value listener.MaxInflightRequest=0 and inflights=0 {"handler": "rate_limit", "url": "/render/?target=carbon.*.*.*.*&from=1663260422&until=1663262222", "peer": "127.0.0.1:49532"}
[2022-09-15T17:17:04.986Z] INFO [access] fetch served {"handler": "render", "url": "/render/?target=carbon.*.*.*.*&from=1663260422&until=1663262222", "peer": "127.0.0.1:49532", "targets": ["carbon.*.*.*.*"], "format": "json", "runtime_seconds": 0.006934026, "query_cache_enabled": true, "from_cache": false, "metrics_fetched": 164, "values_fetched": 19680, "memory_used_bytes": 193964, "http_code": 200}
[2022-09-15T17:17:05.490Z] ERROR [access] JMEICHLE we have this value listener.MaxInflightRequest=0 and inflights=0 {"handler": "rate_limit", "url": "/render/?target=carbon.*.*.*.*&from=1663260425&until=1663262225", "peer": "127.0.0.1:49536"}
^C
```

This appears to be a mis-use of `sender` not `senderRaw` within the CarbonServerListener's Stat function. Changing to senderRaw fixes things:


```
ubuntu@tp135859-ts-carbon-vpc-04620a6a2f1c3a447:~$ sudo service go-carbon stop && sudo truncate -s 0 /var/log/go-carbon/go-carbon.log && sudo service go-carbon start && tail -f /var/log/go-carbon/go-carbon.log
[2022-09-15T17:21:34.700Z] INFO [carbonserver] starting carbonserver {"listen": "0.0.0.0:8080", "whisperData": "/var/lib/graphite/graphite/whisper", "maxGlobs": 100, "scanFrequency": "5m0s"}
[2022-09-15T17:21:34.700Z] INFO [main] started {}
[2022-09-15T17:21:34.700Z] ERROR [restore] readdir failed {"dir": "/var/lib/graphite/go-carbon-dump/", "error": "open /var/lib/graphite/go-carbon-dump/: no such file or directory"}
[2022-09-15T17:21:34.700Z] INFO [restore] restore finished {"dir": "/var/lib/graphite/go-carbon-dump/", "runtime": 0.000062029}
[2022-09-15T17:21:36.146Z] ERROR [access] request denied {"handler": "rate_limit", "url": "/render/?target=carbon.*.*.*.*&from=1663260696&until=1663262496", "peer": "127.0.0.1:49786", "runtime_seconds": 0.000023097, "reason": "index not ready", "http_code": 503}
[2022-09-15T17:21:36.637Z] INFO [carbonserver] file list updated {"handler": "fileListUpdated", "trie_depth": 257, "longest_metric": "service_is_carbon-relay-ng/instance_is_tp135859-ts-carbon-relay-ng-vpc-006ce918040ee96e7/mtype_is_count/unit_is_Metric/dest_is_allmetrics_tp135859-ts-carbon-vpc-dev-10_servers_clovesoftware-dev_com_2004/what_is_durationFlush/type_is_overflow/orig_unit_is_ns", "trie_count_nodes_time": 0.113354115, "file_scan_runtime": 1.823783268, "indexing_runtime": 0.113358591, "rdtime_update_runtime": 0.000000132, "cache_index_runtime": 0.000000188, "total_runtime": 1.937143971, "Files": 1762740, "index_size": 3593625, "pruned_trigrams": 0, "cache_metric_len_before": 0, "cache_metric_len_after": 0, "metrics_known": 1695625, "index_type": "trie", "read_from_cache": true}
[2022-09-15T17:21:36.637Z] INFO [carbonserver] file list updated with cache, starting a new scan immediately {}
[2022-09-15T17:21:36.650Z] ERROR [access] JMEICHLE we have this value listener.MaxInflightRequest=1 and inflights=1 {"handler": "rate_limit", "url": "/render/?target=carbon.*.*.*.*&from=1663260696&until=1663262496", "peer": "127.0.0.1:49788"}
[2022-09-15T17:21:38.660Z] INFO [access] fetch served {"handler": "render", "url": "/render/?target=carbon.*.*.*.*&from=1663260696&until=1663262496", "peer": "127.0.0.1:49788", "targets": ["carbon.*.*.*.*"], "format": "json", "runtime_seconds": 0.008466222, "query_cache_enabled": true, "from_cache": false, "metrics_fetched": 164, "values_fetched": 19680, "memory_used_bytes": 193964, "http_code": 200}
[2022-09-15T17:21:39.165Z] ERROR [access] JMEICHLE we have this value listener.MaxInflightRequest=1 and inflights=1 {"handler": "rate_limit", "url": "/render/?target=carbon.*.*.*.*&from=1663260699&until=1663262499", "peer": "127.0.0.1:49790"}
[2022-09-15T17:21:41.172Z] INFO [access] fetch served {"handler": "render", "url": "/render/?target=carbon.*.*.*.*&from=1663260699&until=1663262499", "peer": "127.0.0.1:49790", "targets": ["carbon.*.*.*.*"], "format": "json", "runtime_seconds": 0.007004994, "query_cache_enabled": true, "from_cache": false, "metrics_fetched": 164, "values_fetched": 19680, "memory_used_bytes": 193964, "http_code": 200}
[2022-09-15T17:21:41.677Z] ERROR [access] JMEICHLE we have this value listener.MaxInflightRequest=1 and inflights=1 {"handler": "rate_limit", "url": "/render/?target=carbon.*.*.*.*&from=1663260701&until=1663262501", "peer": "127.0.0.1:49792"}
[2022-09-15T17:21:43.685Z] INFO [access] fetch served {"handler": "render", "url": "/render/?target=carbon.*.*.*.*&from=1663260701&until=1663262501", "peer": "127.0.0.1:49792", "targets": ["carbon.*.*.*.*"], "format": "json", "runtime_seconds": 0.007911685, "query_cache_enabled": true, "from_cache": false, "metrics_fetched": 164, "values_fetched": 19680, "memory_used_bytes": 193964, "http_code": 200}
[2022-09-15T17:21:44.190Z] ERROR [access] JMEICHLE we have this value listener.MaxInflightRequest=1 and inflights=1 {"handler": "rate_limit", "url": "/render/?target=carbon.*.*.*.*&from=1663260704&until=1663262504", "peer": "127.0.0.1:49794"}
[2022-09-15T17:21:46.199Z] INFO [access] fetch served {"handler": "render", "url": "/render/?target=carbon.*.*.*.*&from=1663260704&until=1663262504", "peer": "127.0.0.1:49794", "targets": ["carbon.*.*.*.*"], "format": "json", "runtime_seconds": 0.008568349, "query_cache_enabled": true, "from_cache": false, "metrics_fetched": 164, "values_fetched": 19680, "memory_used_bytes": 193964, "http_code": 200}
[2022-09-15T17:21:46.393Z] INFO [carbonserver] file list updated {"handler": "fileListUpdated", "trie_depth": 257, "longest_metric": "service_is_carbon-relay-ng/instance_is_tp135859-ts-carbon-relay-ng-vpc-006ce918040ee96e7/mtype_is_count/unit_is_Metric/dest_is_allmetrics_tp135859-ts-carbon-vpc-dev-10_servers_clovesoftware-dev_com_2004/what_is_durationFlush/type_is_overflow/orig_unit_is_ns", "trie_count_nodes_time": 0.142828826, "file_scan_runtime": 9.613283831, "indexing_runtime": 0.14283481, "rdtime_update_runtime": 0.000000079, "cache_index_runtime": 0.000000144, "total_runtime": 9.756122072, "Files": 1762741, "index_size": 3591177, "pruned_trigrams": 0, "cache_metric_len_before": 0, "cache_metric_len_after": 0, "metrics_known": 1695625, "index_type": "trie", "read_from_cache": false}
[2022-09-15T17:21:46.704Z] ERROR [access] JMEICHLE we have this value listener.MaxInflightRequest=1 and inflights=1 {"handler": "rate_limit", "url": "/render/?target=carbon.*.*.*.*&from=1663260706&until=1663262506", "peer": "127.0.0.1:49796"}
[2022-09-15T17:21:48.714Z] INFO [access] fetch served {"handler": "render", "url": "/render/?target=carbon.*.*.*.*&from=1663260706&until=1663262506", "peer": "127.0.0.1:49796", "targets": ["carbon.*.*.*.*"], "format": "json", "runtime_seconds": 0.009083856, "query_cache_enabled": true, "from_cache": false, "metrics_fetched": 164, "values_fetched": 19680, "memory_used_bytes": 193964, "http_code": 200}
[2022-09-15T17:21:49.217Z] ERROR [access] JMEICHLE we have this value listener.MaxInflightRequest=1 and inflights=1 {"handler": "rate_limit", "url": "/render/?target=carbon.*.*.*.*&from=1663260709&until=1663262509", "peer": "127.0.0.1:49798"}
[2022-09-15T17:21:49.701Z] INFO [stat] collect {"endpoint": "local", "metric": "carbon.agents.tp135859-ts-carbon-vpc-04620a6a2f1c3a447.runtime.GOMAXPROCS", "value": 14}
[2022-09-15T17:21:49.701Z] INFO [stat] collect {"endpoint": "local", "metric": "carbon.agents.tp135859-ts-carbon-vpc-04620a6a2f1c3a447.runtime.NumGoroutine", "value": 30}
[2022-09-15T17:21:49.701Z] INFO [stat] collect {"endpoint": "local", "metric": "carbon.agents.tp135859-ts-carbon-vpc-04620a6a2f1c3a447.cache.size", "value": 0}
[2022-09-15T17:21:49.701Z] INFO [stat] collect {"endpoint": "local", "metric": "carbon.agents.tp135859-ts-carbon-vpc-04620a6a2f1c3a447.cache.metrics", "value": 0}
[2022-09-15T17:21:49.701Z] INFO [stat] collect {"endpoint": "local", "metric": "carbon.agents.tp135859-ts-carbon-vpc-04620a6a2f1c3a447.cache.maxSize", "value": 100000000}
[2022-09-15T17:21:49.701Z] INFO [stat] collect {"endpoint": "local", "metric": "carbon.agents.tp135859-ts-carbon-vpc-04620a6a2f1c3a447.cache.notConfirmed", "value": 4096}
[2022-09-15T17:21:49.701Z] INFO [stat] collect {"endpoint": "local", "metric": "carbon.agents.tp135859-ts-carbon-vpc-04620a6a2f1c3a447.cache.queries", "value": 820}
[2022-09-15T17:21:49.701Z] INFO [stat] collect {"endpoint": "local", "metric": "carbon.agents.tp135859-ts-carbon-vpc-04620a6a2f1c3a447.cache.tagsNormalizeErrors", "value": 0}
[2022-09-15T17:21:49.701Z] INFO [stat] collect {"endpoint": "local", "metric": "carbon.agents.tp135859-ts-carbon-vpc-04620a6a2f1c3a447.cache.overflow", "value": 0}
[2022-09-15T17:21:49.701Z] INFO [stat] collect {"endpoint": "local", "metric": "carbon.agents.tp135859-ts-carbon-vpc-04620a6a2f1c3a447.cache.queueBuildCount", "value": 150}
[2022-09-15T17:21:49.701Z] INFO [stat] collect {"endpoint": "local", "metric": "carbon.agents.tp135859-ts-carbon-vpc-04620a6a2f1c3a447.cache.queueBuildTimeMs", "value": 0}
[2022-09-15T17:21:49.701Z] INFO [stat] collect {"endpoint": "local", "metric": "carbon.agents.tp135859-ts-carbon-vpc-04620a6a2f1c3a447.cache.queueWriteoutTime", "value": 0}
[2022-09-15T17:21:49.701Z] INFO [stat] collect {"endpoint": "local", "metric": "carbon.agents.tp135859-ts-carbon-vpc-04620a6a2f1c3a447.cache.droppedRealtimeIndex", "value": 0}
[2022-09-15T17:21:49.702Z] INFO [stat] collect {"endpoint": "local", "metric": "carbon.agents.tp135859-ts-carbon-vpc-04620a6a2f1c3a447.carbonserver.render_requests", "value": 5}
[2022-09-15T17:21:49.702Z] INFO [stat] collect {"endpoint": "local", "metric": "carbon.agents.tp135859-ts-carbon-vpc-04620a6a2f1c3a447.carbonserver.render_errors", "value": 0}
[2022-09-15T17:21:49.702Z] INFO [stat] collect {"endpoint": "local", "metric": "carbon.agents.tp135859-ts-carbon-vpc-04620a6a2f1c3a447.carbonserver.notfound", "value": 0}
[2022-09-15T17:21:49.702Z] INFO [stat] collect {"endpoint": "local", "metric": "carbon.agents.tp135859-ts-carbon-vpc-04620a6a2f1c3a447.carbonserver.find_requests", "value": 0}
[2022-09-15T17:21:49.702Z] INFO [stat] collect {"endpoint": "local", "metric": "carbon.agents.tp135859-ts-carbon-vpc-04620a6a2f1c3a447.carbonserver.find_errors", "value": 0}
[2022-09-15T17:21:49.702Z] INFO [stat] collect {"endpoint": "local", "metric": "carbon.agents.tp135859-ts-carbon-vpc-04620a6a2f1c3a447.carbonserver.find_zero", "value": 0}
[2022-09-15T17:21:49.702Z] INFO [stat] collect {"endpoint": "local", "metric": "carbon.agents.tp135859-ts-carbon-vpc-04620a6a2f1c3a447.carbonserver.list_requests", "value": 0}
[2022-09-15T17:21:49.702Z] INFO [stat] collect {"endpoint": "local", "metric": "carbon.agents.tp135859-ts-carbon-vpc-04620a6a2f1c3a447.carbonserver.list_errors", "value": 0}
[2022-09-15T17:21:49.702Z] INFO [stat] collect {"endpoint": "local", "metric": "carbon.agents.tp135859-ts-carbon-vpc-04620a6a2f1c3a447.carbonserver.details_requests", "value": 0}
[2022-09-15T17:21:49.702Z] INFO [stat] collect {"endpoint": "local", "metric": "carbon.agents.tp135859-ts-carbon-vpc-04620a6a2f1c3a447.carbonserver.details_errors", "value": 0}
[2022-09-15T17:21:49.702Z] INFO [stat] collect {"endpoint": "local", "metric": "carbon.agents.tp135859-ts-carbon-vpc-04620a6a2f1c3a447.carbonserver.cache_hit", "value": 0}
[2022-09-15T17:21:49.702Z] INFO [stat] collect {"endpoint": "local", "metric": "carbon.agents.tp135859-ts-carbon-vpc-04620a6a2f1c3a447.carbonserver.cache_miss", "value": 0}
[2022-09-15T17:21:49.702Z] INFO [stat] collect {"endpoint": "local", "metric": "carbon.agents.tp135859-ts-carbon-vpc-04620a6a2f1c3a447.carbonserver.cache_work_time_ns", "value": 0}
[2022-09-15T17:21:49.702Z] INFO [stat] collect {"endpoint": "local", "metric": "carbon.agents.tp135859-ts-carbon-vpc-04620a6a2f1c3a447.carbonserver.cache_wait_time_fetch_ns", "value": 277495}
[2022-09-15T17:21:49.702Z] INFO [stat] collect {"endpoint": "local", "metric": "carbon.agents.tp135859-ts-carbon-vpc-04620a6a2f1c3a447.carbonserver.cache_requests", "value": 0}
[2022-09-15T17:21:49.702Z] INFO [stat] collect {"endpoint": "local", "metric": "carbon.agents.tp135859-ts-carbon-vpc-04620a6a2f1c3a447.carbonserver.disk_wait_time_ns", "value": 5311090}
[2022-09-15T17:21:49.702Z] INFO [stat] collect {"endpoint": "local", "metric": "carbon.agents.tp135859-ts-carbon-vpc-04620a6a2f1c3a447.carbonserver.disk_requests", "value": 820}
[2022-09-15T17:21:49.702Z] INFO [stat] collect {"endpoint": "local", "metric": "carbon.agents.tp135859-ts-carbon-vpc-04620a6a2f1c3a447.carbonserver.points_returned", "value": 98400}
[2022-09-15T17:21:49.702Z] INFO [stat] collect {"endpoint": "local", "metric": "carbon.agents.tp135859-ts-carbon-vpc-04620a6a2f1c3a447.carbonserver.metrics_returned", "value": 820}
[2022-09-15T17:21:49.702Z] INFO [stat] collect {"endpoint": "local", "metric": "carbon.agents.tp135859-ts-carbon-vpc-04620a6a2f1c3a447.carbonserver.metrics_found", "value": 0}
[2022-09-15T17:21:49.702Z] INFO [stat] collect {"endpoint": "local", "metric": "carbon.agents.tp135859-ts-carbon-vpc-04620a6a2f1c3a447.carbonserver.fetch_size_bytes", "value": 969820}
[2022-09-15T17:21:49.702Z] INFO [stat] collect {"endpoint": "local", "metric": "carbon.agents.tp135859-ts-carbon-vpc-04620a6a2f1c3a447.carbonserver.metrics_known", "value": 1695625}
[2022-09-15T17:21:49.702Z] INFO [stat] collect {"endpoint": "local", "metric": "carbon.agents.tp135859-ts-carbon-vpc-04620a6a2f1c3a447.carbonserver.index_build_time_ns", "value": 256193401}
[2022-09-15T17:21:49.702Z] INFO [stat] collect {"endpoint": "local", "metric": "carbon.agents.tp135859-ts-carbon-vpc-04620a6a2f1c3a447.carbonserver.file_scan_time_ns", "value": 11437067099}
[2022-09-15T17:21:49.702Z] INFO [stat] collect {"endpoint": "local", "metric": "carbon.agents.tp135859-ts-carbon-vpc-04620a6a2f1c3a447.carbonserver.query_cache_hit", "value": 0}
[2022-09-15T17:21:49.702Z] INFO [stat] collect {"endpoint": "local", "metric": "carbon.agents.tp135859-ts-carbon-vpc-04620a6a2f1c3a447.carbonserver.query_cache_miss", "value": 5}
[2022-09-15T17:21:49.702Z] INFO [stat] collect {"endpoint": "local", "metric": "carbon.agents.tp135859-ts-carbon-vpc-04620a6a2f1c3a447.carbonserver.find_cache_hit", "value": 0}
[2022-09-15T17:21:49.702Z] INFO [stat] collect {"endpoint": "local", "metric": "carbon.agents.tp135859-ts-carbon-vpc-04620a6a2f1c3a447.carbonserver.find_cache_miss", "value": 0}
[2022-09-15T17:21:49.702Z] INFO [stat] collect {"endpoint": "local", "metric": "carbon.agents.tp135859-ts-carbon-vpc-04620a6a2f1c3a447.carbonserver.inflight_requests_count", "value": 1}
[2022-09-15T17:21:49.702Z] INFO [stat] collect {"endpoint": "local", "metric": "carbon.agents.tp135859-ts-carbon-vpc-04620a6a2f1c3a447.carbonserver.inflight_requests_limit", "value": 1}
[2022-09-15T17:21:49.702Z] INFO [stat] collect {"endpoint": "local", "metric": "carbon.agents.tp135859-ts-carbon-vpc-04620a6a2f1c3a447.carbonserver.rejected_too_many_requests", "value": 0}
[2022-09-15T17:21:49.702Z] INFO [stat] collect {"endpoint": "local", "metric": "carbon.agents.tp135859-ts-carbon-vpc-04620a6a2f1c3a447.carbonserver.alloc", "value": 1146309896}
[2022-09-15T17:21:49.702Z] INFO [stat] collect {"endpoint": "local", "metric": "carbon.agents.tp135859-ts-carbon-vpc-04620a6a2f1c3a447.carbonserver.total_alloc", "value": 2200018184}
[2022-09-15T17:21:49.702Z] INFO [stat] collect {"endpoint": "local", "metric": "carbon.agents.tp135859-ts-carbon-vpc-04620a6a2f1c3a447.carbonserver.num_gc", "value": 16}
[2022-09-15T17:21:49.702Z] INFO [stat] collect {"endpoint": "local", "metric": "carbon.agents.tp135859-ts-carbon-vpc-04620a6a2f1c3a447.carbonserver.pause_ns", "value": 841271}
[2022-09-15T17:21:49.702Z] INFO [stat] collect {"endpoint": "local", "metric": "carbon.agents.tp135859-ts-carbon-vpc-04620a6a2f1c3a447.carbonserver.request_codes.info.1xx", "value": 0}
[2022-09-15T17:21:49.702Z] INFO [stat] collect {"endpoint": "local", "metric": "carbon.agents.tp135859-ts-carbon-vpc-04620a6a2f1c3a447.carbonserver.request_codes.info.2xx", "value": 0}
[2022-09-15T17:21:49.702Z] INFO [stat] collect {"endpoint": "local", "metric": "carbon.agents.tp135859-ts-carbon-vpc-04620a6a2f1c3a447.carbonserver.request_codes.info.3xx", "value": 0}
[2022-09-15T17:21:49.702Z] INFO [stat] collect {"endpoint": "local", "metric": "carbon.agents.tp135859-ts-carbon-vpc-04620a6a2f1c3a447.carbonserver.request_codes.info.4xx", "value": 0}
[2022-09-15T17:21:49.702Z] INFO [stat] collect {"endpoint": "local", "metric": "carbon.agents.tp135859-ts-carbon-vpc-04620a6a2f1c3a447.carbonserver.request_codes.info.5xx", "value": 0}
[2022-09-15T17:21:49.702Z] INFO [stat] collect {"endpoint": "local", "metric": "carbon.agents.tp135859-ts-carbon-vpc-04620a6a2f1c3a447.carbonserver.request_codes.capabilities.1xx", "value": 0}
[2022-09-15T17:21:49.702Z] INFO [stat] collect {"endpoint": "local", "metric": "carbon.agents.tp135859-ts-carbon-vpc-04620a6a2f1c3a447.carbonserver.request_codes.capabilities.2xx", "value": 0}
[2022-09-15T17:21:49.702Z] INFO [stat] collect {"endpoint": "local", "metric": "carbon.agents.tp135859-ts-carbon-vpc-04620a6a2f1c3a447.carbonserver.request_codes.capabilities.3xx", "value": 0}
[2022-09-15T17:21:49.702Z] INFO [stat] collect {"endpoint": "local", "metric": "carbon.agents.tp135859-ts-carbon-vpc-04620a6a2f1c3a447.carbonserver.request_codes.capabilities.4xx", "value": 0}
[2022-09-15T17:21:49.702Z] INFO [stat] collect {"endpoint": "local", "metric": "carbon.agents.tp135859-ts-carbon-vpc-04620a6a2f1c3a447.carbonserver.request_codes.capabilities.5xx", "value": 0}
[2022-09-15T17:21:49.702Z] INFO [stat] collect {"endpoint": "local", "metric": "carbon.agents.tp135859-ts-carbon-vpc-04620a6a2f1c3a447.carbonserver.request_codes.combined.1xx", "value": 0}
[2022-09-15T17:21:49.702Z] INFO [stat] collect {"endpoint": "local", "metric": "carbon.agents.tp135859-ts-carbon-vpc-04620a6a2f1c3a447.carbonserver.request_codes.combined.2xx", "value": 5}
[2022-09-15T17:21:49.702Z] INFO [stat] collect {"endpoint": "local", "metric": "carbon.agents.tp135859-ts-carbon-vpc-04620a6a2f1c3a447.carbonserver.request_codes.combined.3xx", "value": 0}
[2022-09-15T17:21:49.702Z] INFO [stat] collect {"endpoint": "local", "metric": "carbon.agents.tp135859-ts-carbon-vpc-04620a6a2f1c3a447.carbonserver.request_codes.combined.4xx", "value": 0}
[2022-09-15T17:21:49.702Z] INFO [stat] collect {"endpoint": "local", "metric": "carbon.agents.tp135859-ts-carbon-vpc-04620a6a2f1c3a447.carbonserver.request_codes.combined.5xx", "value": 1}
[2022-09-15T17:21:49.702Z] INFO [stat] collect {"endpoint": "local", "metric": "carbon.agents.tp135859-ts-carbon-vpc-04620a6a2f1c3a447.carbonserver.request_codes.find.1xx", "value": 0}
[2022-09-15T17:21:49.702Z] INFO [stat] collect {"endpoint": "local", "metric": "carbon.agents.tp135859-ts-carbon-vpc-04620a6a2f1c3a447.carbonserver.request_codes.find.2xx", "value": 0}
[2022-09-15T17:21:49.702Z] INFO [stat] collect {"endpoint": "local", "metric": "carbon.agents.tp135859-ts-carbon-vpc-04620a6a2f1c3a447.carbonserver.request_codes.find.3xx", "value": 0}
[2022-09-15T17:21:49.702Z] INFO [stat] collect {"endpoint": "local", "metric": "carbon.agents.tp135859-ts-carbon-vpc-04620a6a2f1c3a447.carbonserver.request_codes.find.4xx", "value": 0}
[2022-09-15T17:21:49.702Z] INFO [stat] collect {"endpoint": "local", "metric": "carbon.agents.tp135859-ts-carbon-vpc-04620a6a2f1c3a447.carbonserver.request_codes.find.5xx", "value": 0}
[2022-09-15T17:21:49.702Z] INFO [stat] collect {"endpoint": "local", "metric": "carbon.agents.tp135859-ts-carbon-vpc-04620a6a2f1c3a447.carbonserver.request_codes.list.1xx", "value": 0}
[2022-09-15T17:21:49.702Z] INFO [stat] collect {"endpoint": "local", "metric": "carbon.agents.tp135859-ts-carbon-vpc-04620a6a2f1c3a447.carbonserver.request_codes.list.2xx", "value": 0}
[2022-09-15T17:21:49.702Z] INFO [stat] collect {"endpoint": "local", "metric": "carbon.agents.tp135859-ts-carbon-vpc-04620a6a2f1c3a447.carbonserver.request_codes.list.3xx", "value": 0}
[2022-09-15T17:21:49.702Z] INFO [stat] collect {"endpoint": "local", "metric": "carbon.agents.tp135859-ts-carbon-vpc-04620a6a2f1c3a447.carbonserver.request_codes.list.4xx", "value": 0}
[2022-09-15T17:21:49.702Z] INFO [stat] collect {"endpoint": "local", "metric": "carbon.agents.tp135859-ts-carbon-vpc-04620a6a2f1c3a447.carbonserver.request_codes.list.5xx", "value": 0}
[2022-09-15T17:21:49.702Z] INFO [stat] collect {"endpoint": "local", "metric": "carbon.agents.tp135859-ts-carbon-vpc-04620a6a2f1c3a447.carbonserver.request_codes.render.1xx", "value": 0}
[2022-09-15T17:21:49.702Z] INFO [stat] collect {"endpoint": "local", "metric": "carbon.agents.tp135859-ts-carbon-vpc-04620a6a2f1c3a447.carbonserver.request_codes.render.2xx", "value": 5}
[2022-09-15T17:21:49.702Z] INFO [stat] collect {"endpoint": "local", "metric": "carbon.agents.tp135859-ts-carbon-vpc-04620a6a2f1c3a447.carbonserver.request_codes.render.3xx", "value": 0}
[2022-09-15T17:21:49.702Z] INFO [stat] collect {"endpoint": "local", "metric": "carbon.agents.tp135859-ts-carbon-vpc-04620a6a2f1c3a447.carbonserver.request_codes.render.4xx", "value": 0}
[2022-09-15T17:21:49.702Z] INFO [stat] collect {"endpoint": "local", "metric": "carbon.agents.tp135859-ts-carbon-vpc-04620a6a2f1c3a447.carbonserver.request_codes.render.5xx", "value": 1}
[2022-09-15T17:21:49.702Z] INFO [stat] collect {"endpoint": "local", "metric": "carbon.agents.tp135859-ts-carbon-vpc-04620a6a2f1c3a447.carbonserver.request_codes.details.1xx", "value": 0}
[2022-09-15T17:21:49.702Z] INFO [stat] collect {"endpoint": "local", "metric": "carbon.agents.tp135859-ts-carbon-vpc-04620a6a2f1c3a447.carbonserver.request_codes.details.2xx", "value": 0}
[2022-09-15T17:21:49.702Z] INFO [stat] collect {"endpoint": "local", "metric": "carbon.agents.tp135859-ts-carbon-vpc-04620a6a2f1c3a447.carbonserver.request_codes.details.3xx", "value": 0}
[2022-09-15T17:21:49.702Z] INFO [stat] collect {"endpoint": "local", "metric": "carbon.agents.tp135859-ts-carbon-vpc-04620a6a2f1c3a447.carbonserver.request_codes.details.4xx", "value": 0}
[2022-09-15T17:21:49.702Z] INFO [stat] collect {"endpoint": "local", "metric": "carbon.agents.tp135859-ts-carbon-vpc-04620a6a2f1c3a447.carbonserver.request_codes.details.5xx", "value": 0}
[2022-09-15T17:21:49.702Z] INFO [stat] collect {"endpoint": "local", "metric": "carbon.agents.tp135859-ts-carbon-vpc-04620a6a2f1c3a447.carbonserver.requests_in_0ms_to_100ms", "value": 1}
[2022-09-15T17:21:49.702Z] INFO [stat] collect {"endpoint": "local", "metric": "carbon.agents.tp135859-ts-carbon-vpc-04620a6a2f1c3a447.carbonserver.requests_in_100ms_to_200ms", "value": 0}
[2022-09-15T17:21:49.702Z] INFO [stat] collect {"endpoint": "local", "metric": "carbon.agents.tp135859-ts-carbon-vpc-04620a6a2f1c3a447.carbonserver.requests_in_200ms_to_300ms", "value": 0}
[2022-09-15T17:21:49.702Z] INFO [stat] collect {"endpoint": "local", "metric": "carbon.agents.tp135859-ts-carbon-vpc-04620a6a2f1c3a447.carbonserver.requests_in_300ms_to_400ms", "value": 5}
[2022-09-15T17:21:49.702Z] INFO [stat] collect {"endpoint": "local", "metric": "carbon.agents.tp135859-ts-carbon-vpc-04620a6a2f1c3a447.carbonserver.requests_in_400ms_to_500ms", "value": 0}
[2022-09-15T17:21:49.702Z] INFO [stat] collect {"endpoint": "local", "metric": "carbon.agents.tp135859-ts-carbon-vpc-04620a6a2f1c3a447.carbonserver.requests_in_500ms_to_600ms", "value": 0}
[2022-09-15T17:21:49.702Z] INFO [stat] collect {"endpoint": "local", "metric": "carbon.agents.tp135859-ts-carbon-vpc-04620a6a2f1c3a447.carbonserver.requests_in_600ms_to_700ms", "value": 0}
[2022-09-15T17:21:49.702Z] INFO [stat] collect {"endpoint": "local", "metric": "carbon.agents.tp135859-ts-carbon-vpc-04620a6a2f1c3a447.carbonserver.requests_in_700ms_to_800ms", "value": 0}
[2022-09-15T17:21:49.702Z] INFO [stat] collect {"endpoint": "local", "metric": "carbon.agents.tp135859-ts-carbon-vpc-04620a6a2f1c3a447.carbonserver.requests_in_800ms_to_900ms", "value": 0}
[2022-09-15T17:21:49.702Z] INFO [stat] collect {"endpoint": "local", "metric": "carbon.agents.tp135859-ts-carbon-vpc-04620a6a2f1c3a447.carbonserver.requests_in_900ms_to_1000ms", "value": 0}
[2022-09-15T17:21:49.702Z] INFO [stat] collect {"endpoint": "local", "metric": "carbon.agents.tp135859-ts-carbon-vpc-04620a6a2f1c3a447.carbonserver.requests_in_1000ms_to_1100ms", "value": 0}
[2022-09-15T17:21:49.702Z] INFO [stat] collect {"endpoint": "local", "metric": "carbon.agents.tp135859-ts-carbon-vpc-04620a6a2f1c3a447.carbonserver.request_time_99th_percentile_ns", "value": 2009483640}
[2022-09-15T17:21:49.702Z] INFO [stat] collect {"endpoint": "local", "metric": "carbon.agents.tp135859-ts-carbon-vpc-04620a6a2f1c3a447.carbonserver.request_time_98th_percentile_ns", "value": 2009483640}
[2022-09-15T17:21:49.702Z] INFO [stat] collect {"endpoint": "local", "metric": "carbon.agents.tp135859-ts-carbon-vpc-04620a6a2f1c3a447.carbonserver.request_time_95th_percentile_ns", "value": 2009483640}
[2022-09-15T17:21:49.702Z] INFO [stat] collect {"endpoint": "local", "metric": "carbon.agents.tp135859-ts-carbon-vpc-04620a6a2f1c3a447.carbonserver.request_time_75th_percentile_ns", "value": 2009432908}
[2022-09-15T17:21:49.702Z] INFO [stat] collect {"endpoint": "local", "metric": "carbon.agents.tp135859-ts-carbon-vpc-04620a6a2f1c3a447.carbonserver.request_time_50th_percentile_ns", "value": 2008356470}
[2022-09-15T17:21:49.702Z] INFO [stat] collect {"endpoint": "local", "metric": "carbon.agents.tp135859-ts-carbon-vpc-04620a6a2f1c3a447.udp.metricsReceived", "value": 0}
[2022-09-15T17:21:49.702Z] INFO [stat] collect {"endpoint": "local", "metric": "carbon.agents.tp135859-ts-carbon-vpc-04620a6a2f1c3a447.udp.errors", "value": 0}
[2022-09-15T17:21:49.702Z] INFO [stat] collect {"endpoint": "local", "metric": "carbon.agents.tp135859-ts-carbon-vpc-04620a6a2f1c3a447.tcp.metricsReceived", "value": 0}
[2022-09-15T17:21:49.702Z] INFO [stat] collect {"endpoint": "local", "metric": "carbon.agents.tp135859-ts-carbon-vpc-04620a6a2f1c3a447.tcp.active", "value": 0}
[2022-09-15T17:21:49.702Z] INFO [stat] collect {"endpoint": "local", "metric": "carbon.agents.tp135859-ts-carbon-vpc-04620a6a2f1c3a447.tcp.errors", "value": 0}
[2022-09-15T17:21:49.702Z] INFO [stat] collect {"endpoint": "local", "metric": "carbon.agents.tp135859-ts-carbon-vpc-04620a6a2f1c3a447.pickle.metricsReceived", "value": 0}
[2022-09-15T17:21:49.702Z] INFO [stat] collect {"endpoint": "local", "metric": "carbon.agents.tp135859-ts-carbon-vpc-04620a6a2f1c3a447.pickle.active", "value": 0}
[2022-09-15T17:21:49.702Z] INFO [stat] collect {"endpoint": "local", "metric": "carbon.agents.tp135859-ts-carbon-vpc-04620a6a2f1c3a447.pickle.errors", "value": 0}
[2022-09-15T17:21:49.702Z] INFO [stat] collect {"endpoint": "local", "metric": "carbon.agents.tp135859-ts-carbon-vpc-04620a6a2f1c3a447.persister.updateOperations", "value": 0}
[2022-09-15T17:21:49.702Z] INFO [stat] collect {"endpoint": "local", "metric": "carbon.agents.tp135859-ts-carbon-vpc-04620a6a2f1c3a447.persister.committedPoints", "value": 0}
[2022-09-15T17:21:49.702Z] INFO [stat] collect {"endpoint": "local", "metric": "carbon.agents.tp135859-ts-carbon-vpc-04620a6a2f1c3a447.persister.pointsPerUpdate", "value": 0}
[2022-09-15T17:21:49.702Z] INFO [stat] collect {"endpoint": "local", "metric": "carbon.agents.tp135859-ts-carbon-vpc-04620a6a2f1c3a447.persister.created", "value": 0}
[2022-09-15T17:21:49.702Z] INFO [stat] collect {"endpoint": "local", "metric": "carbon.agents.tp135859-ts-carbon-vpc-04620a6a2f1c3a447.persister.throttledCreates", "value": 0}
[2022-09-15T17:21:49.702Z] INFO [stat] collect {"endpoint": "local", "metric": "carbon.agents.tp135859-ts-carbon-vpc-04620a6a2f1c3a447.persister.maxCreatesPerSecond", "value": 0}
[2022-09-15T17:21:49.702Z] INFO [stat] collect {"endpoint": "local", "metric": "carbon.agents.tp135859-ts-carbon-vpc-04620a6a2f1c3a447.persister.maxUpdatesPerSecond", "value": 0}
[2022-09-15T17:21:49.702Z] INFO [stat] collect {"endpoint": "local", "metric": "carbon.agents.tp135859-ts-carbon-vpc-04620a6a2f1c3a447.persister.workers", "value": 8}
[2022-09-15T17:21:49.702Z] INFO [stat] collect {"endpoint": "local", "metric": "carbon.agents.tp135859-ts-carbon-vpc-04620a6a2f1c3a447.persister.extended", "value": 0}
[2022-09-15T17:21:51.226Z] INFO [access] fetch served {"handler": "render", "url": "/render/?target=carbon.*.*.*.*&from=1663260709&until=1663262509", "peer": "127.0.0.1:49798", "targets": ["carbon.*.*.*.*"], "format": "json", "runtime_seconds": 0.008193772, "query_cache_enabled": true, "from_cache": false, "metrics_fetched": 164, "values_fetched": 19680, "memory_used_bytes": 193964, "http_code": 200}
[2022-09-15T17:21:51.730Z] ERROR [access] JMEICHLE we have this value listener.MaxInflightRequest=1 and inflights=0 {"handler": "rate_limit", "url": "/render/?target=carbon.*.*.*.*&from=1663260711&until=1663262511", "peer": "127.0.0.1:49800"}
[2022-09-15T17:21:53.739Z] INFO [access] fetch served {"handler": "render", "url": "/render/?target=carbon.*.*.*.*&from=1663260711&until=1663262511", "peer": "127.0.0.1:49800", "targets": ["carbon.*.*.*.*"], "format": "json", "runtime_seconds": 0.008551166, "query_cache_enabled": true, "from_cache": false, "metrics_fetched": 164, "values_fetched": 19680, "memory_used_bytes": 193964, "http_code": 200}
[2022-09-15T17:21:54.244Z] ERROR [access] JMEICHLE we have this value listener.MaxInflightRequest=1 and inflights=0 {"handler": "rate_limit", "url": "/render/?target=carbon.*.*.*.*&from=1663260714&until=1663262514", "peer": "127.0.0.1:49802"}
^C
```
