### PR TITLE
Fix request duration bucket metrics naming

### DIFF
--- a/carbonserver/carbonserver.go
+++ b/carbonserver/carbonserver.go
@@ -1543,7 +1543,11 @@ func (listener *CarbonserverListener) Stat(send helper.StatCallback) {
 	bucketStart := 0
 	bucketEnd := 10
 	for i := 0; i <= listener.buckets; i++ {
-		sender(fmt.Sprintf("requests_in_%dms_to_%dms", bucketStart, bucketEnd), &listener.timeBuckets[i], send)
+		metricName := fmt.Sprintf("requests_in_%dms_to_%dms", bucketStart, bucketEnd)
+		if i == listener.buckets {
+			metricName = fmt.Sprintf("requests_in_%dms_to_inf", bucketStart)
+		}
+		sender(metricName, &listener.timeBuckets[i], send)
 		if bucketStart == 0 {
 			bucketStart = 1
 		}

--- a/carbonserver/carbonserver.go
+++ b/carbonserver/carbonserver.go
@@ -1540,8 +1540,15 @@ func (listener *CarbonserverListener) Stat(send helper.StatCallback) {
 			sender(fmt.Sprintf("request_codes.%s.%vxx", name, i+1), &codes[i], send)
 		}
 	}
+	bucketStart := 0
+	bucketEnd := 10
 	for i := 0; i <= listener.buckets; i++ {
-		sender(fmt.Sprintf("requests_in_%dms_to_%dms", i*100, (i+1)*100), &listener.timeBuckets[i], send)
+		sender(fmt.Sprintf("requests_in_%dms_to_%dms", bucketStart, bucketEnd), &listener.timeBuckets[i], send)
+		if bucketStart == 0 {
+			bucketStart = 1
+		}
+		bucketStart *= 10
+		bucketEnd *= 10
 	}
 
 	// Computing response percentiles


### PR DESCRIPTION
The request duration buckets are logarithmic:
https://github.com/go-graphite/go-carbon/blob/master/carbonserver/carbonserver.go#L1544

However, they were named as if they were linear. This PR fixes the metric naming.