### PR TITLE
Add carbonserver render tracing

### DIFF
--- a/carbon/app.go
+++ b/carbon/app.go
@@ -508,6 +508,7 @@ func (app *App) Start(version string) (err error) {
 
 		carbonserver.SetMaxInflightRequests(conf.Carbonserver.MaxInflightRequests)
 		carbonserver.SetNoServiceWhenIndexIsNotReady(conf.Carbonserver.NoServiceWhenIndexIsNotReady)
+		carbonserver.SetRenderTraceLoggingEnabled(conf.Carbonserver.RenderTraceLoggingEnabled)
 
 		if conf.Carbonserver.RequestTimeout != nil {
 			carbonserver.SetRequestTimeout(conf.Carbonserver.RequestTimeout.Value())

--- a/carbon/config.go
+++ b/carbon/config.go
@@ -155,6 +155,8 @@ type carbonserverConfig struct {
 		MaxInflightRequests uint      `toml:"max-inflight-requests"`
 		RequestTimeout      *Duration `toml:"request-timeout"`
 	} `toml:"api-per-path-rate-limiters"`
+
+	RenderTraceLoggingEnabled bool `toml:"render-trace-logging-enabled"`
 }
 
 type pprofConfig struct {

--- a/carbonserver/carbonserver.go
+++ b/carbonserver/carbonserver.go
@@ -291,6 +291,8 @@ type CarbonserverListener struct {
 	NoServiceWhenIndexIsNotReady bool
 	apiPerPathRatelimiter        map[string]*ApiPerPathRatelimiter
 	globQueryRateLimiters        []*GlobQueryRateLimiter
+
+	renderTraceLoggingEnabled bool
 }
 
 type prometheus struct {
@@ -623,6 +625,10 @@ func (listener *CarbonserverListener) SetHeavyGlobQueryRateLimiters(rls []*GlobQ
 }
 func (listener *CarbonserverListener) SetAPIPerPathRateLimiter(rls map[string]*ApiPerPathRatelimiter) {
 	listener.apiPerPathRatelimiter = rls
+}
+
+func (listener *CarbonserverListener) SetRenderTraceLoggingEnabled(enabled bool) {
+	listener.renderTraceLoggingEnabled = enabled
 }
 
 // skipcq: RVV-B0011


### PR DESCRIPTION
These additions are applied in order to investigate the performance degradation seen on some of the cases over gRPC implementation.