### PR TITLE
Add gRPC initial win size of 4MB for less latency

### DIFF
--- a/carbonserver/carbonserver.go
+++ b/carbonserver/carbonserver.go
@@ -2084,14 +2084,17 @@ func (listener *CarbonserverListener) ListenGRPC(listen string) error {
 	}
 
 	var opts []grpc.ServerOption
-	opts = append(opts, grpc.KeepaliveEnforcementPolicy(keepalive.EnforcementPolicy{
-		MinTime:             10 * time.Second,
-		PermitWithoutStream: true,
-	}))
-	opts = append(opts, grpc.KeepaliveParams(keepalive.ServerParameters{
-		Time:    60 * time.Second,
-		Timeout: 20 * time.Second,
-	}))
+	opts = append(opts,
+		grpc.KeepaliveEnforcementPolicy(keepalive.EnforcementPolicy{
+			MinTime:             10 * time.Second,
+			PermitWithoutStream: true,
+		}),
+		grpc.KeepaliveParams(keepalive.ServerParameters{
+			Time:    60 * time.Second,
+			Timeout: 20 * time.Second,
+		}))
+	// TODO: make initial window size configurable
+	opts = append(opts, grpc.InitialWindowSize(4*1024*1024), grpc.InitialConnWindowSize(4*1024*1024))
 	opts = append(opts, grpc.ChainStreamInterceptor(
 		grpcutil.StreamServerTimeHandler(listener.bucketRequestTimesGRPC),
 		grpcutil.StreamServerStatusMetricHandler(statusCodes, listener.prometheus.request),


### PR DESCRIPTION
The default behavior of go-grpc is to use BDP and update the window accordingly. The default initial window in this mode is 64KB.
However, 64KB is way smaller than our desired window size and this probably causes more time needed for streams to reach the desired size. So, we expect to see faster responses for our big messages (majorly renders).
We have seen that the streaming phase of gRPC render requests are slower than their counterpart in HTTP, which lead to this tuning.
This PR proposes a big initial window (4MB) to reduce the latency observed while using gRPC comparing to HTTP.