### PR TITLE
Decrease gRPC streaming channel size

### DIFF
--- a/carbonserver/render.go
+++ b/carbonserver/render.go
@@ -716,6 +716,7 @@ func (listener *CarbonserverListener) Render(req *protov2.MultiFetchRequest, str
 			}
 		}
 		metricGlobMap := getMetricGlobMapFromExpandedGlobs(expandedGlobs)
+		tle.MetricGlobMapLength = len(metricGlobMap)
 		go func() {
 			prepareT0 := time.Now()
 			listener.prepareDataStream(ctx, format, targets, metricGlobMap, responseChan)
@@ -725,7 +726,7 @@ func (listener *CarbonserverListener) Render(req *protov2.MultiFetchRequest, str
 	}
 
 	// TODO: should chan buffer size be configurable?
-	responseChanToStream := make(chan response, 1000)
+	responseChanToStream := make(chan response, 100)
 	var fromCache bool
 	var err error
 	if listener.streamingQueryCacheEnabled {
@@ -739,7 +740,7 @@ func (listener *CarbonserverListener) Render(req *protov2.MultiFetchRequest, str
 		case !found:
 			atomic.AddUint64(&listener.metrics.QueryCacheMiss, 1)
 			// TODO: should chan buffer size be configurable?
-			responseChan := make(chan response, 1000)
+			responseChan := make(chan response, 100)
 			err = fetchMetricsFunc(responseChan)
 			if err != nil {
 				item.StoreAbort()
@@ -839,4 +840,5 @@ type traceLogEntries struct {
 	StreamDuration        float64 `json:"stream_duration"`
 	MarshalDuration       float64 `json:"marshal_duration"`
 	TotalDuration         float64 `json:"total_duration"`
+	MetricGlobMapLength   int     `json:"metric_glob_map_length"`
 }


### PR DESCRIPTION
Go allocates the memory for the capacity given while initializing the channels. Therefore, having a big channel can cost a lot. This commit decreases the channel size. However, it is probably better to determine the size dynamically, and by the result of glob expansion. So this commit also adds one more field to tle to help find a logic for setting the size of the channel.