### PR TITLE
Use protojson.Marshal for produce json from the proto messages

### DIFF
--- a/carbonserver/info.go
+++ b/carbonserver/info.go
@@ -2,7 +2,6 @@ package carbonserver
 
 import (
 	"context"
-	"encoding/json"
 	"io"
 	"net/http"
 	_ "net/http/pprof" // skipcq: GO-S2108
@@ -18,6 +17,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/peer"
 	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/encoding/protojson"
 )
 
 func (listener *CarbonserverListener) infoHandler(wr http.ResponseWriter, req *http.Request) {
@@ -149,12 +149,9 @@ func (listener *CarbonserverListener) infoHandler(wr http.ResponseWriter, req *h
 	switch formatCode {
 	case jsonFormat:
 		contentType = httpHeaders.ContentTypeJSON
-		//skipcq: VET-V0008
-		//nolint:govet
-		b, err = json.Marshal(response)
+		b, err = protojson.Marshal(response.ProtoReflect().Interface())
 	case protoV2Format:
 		contentType = httpHeaders.ContentTypeCarbonAPIv2PB
-
 		r := response.Metrics[0]
 		response := protov2.InfoResponse{
 			Name:              r.Name,

--- a/carbonserver/render.go
+++ b/carbonserver/render.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"crypto/md5"
 	"encoding/hex"
-	"encoding/json"
 	"fmt"
 	"io"
 	"math"
@@ -20,6 +19,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/peer"
 	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/encoding/protojson"
 
 	"github.com/go-graphite/carbonzipper/zipper/httpHeaders"
 	"github.com/go-graphite/go-whisper"
@@ -539,9 +539,7 @@ func (listener *CarbonserverListener) prepareDataProto(ctx context.Context, logg
 	// We still keep old json format, because it's painful to deal with math.NaN that can occur in new format.
 	case jsonFormat:
 		contentType = "application/json"
-		//skipcq: VET-V0008
-		//nolint:govet
-		b, err = json.Marshal(multiv2)
+		b, err = protojson.Marshal(multiv2.ProtoReflect().Interface())
 	case protoV2Format:
 		contentType = httpHeaders.ContentTypeCarbonAPIv2PB
 		b, err = multiv2.MarshalVT()


### PR DESCRIPTION
Should fix pesky "call of json.Marshal copies lock value" from go vet and linters.