### PR TITLE
Fixing typo with go tip, update Docker base images

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -72,7 +72,7 @@ jobs:
           make sum-files
 
       - name: Upload Artifact
-        if: ${{ matrix.go == '^1' }} # only upload artifact when built with latest go
+        if: ${{ matrix.go == 'tip' }} # only upload artifact when built with latest go
         id: artifact
         uses: actions/upload-artifact@v3
         with:
@@ -85,7 +85,7 @@ jobs:
             md5sum
 
       - name: Push packages to the autobuilds repo
-        if: ${{ github.event_name == 'push' && matrix.go == '^1' }} # only when built from master with latest go
+        if: ${{ github.event_name == 'push' && matrix.go == 'tip' }} # only when built from master with latest go
         run: make DEVEL=1 packagecloud-autobuilds
         env:
           PACKAGECLOUD_TOKEN: ${{ secrets.PACKAGECLOUD_TOKEN }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.17.4-alpine3.15 AS build
+FROM golang:1.20-alpine3.17 AS build
 
 COPY . /usr/local/src/go-carbon
 RUN apk add --update git make bash \
@@ -6,7 +6,7 @@ RUN apk add --update git make bash \
  && make go-carbon \
  && chmod +x go-carbon && cp -fv go-carbon /tmp
 
-FROM alpine:3.15
+FROM alpine:3.17
 
 RUN addgroup -S carbon && adduser -S carbon -G carbon \
     && mkdir -p /var/lib/graphite/whisper /var/lib/graphite/dump /var/lib/graphite/tagging /var/log/go-carbon /etc/go-carbon/ \

--- a/Dockerfile.debug
+++ b/Dockerfile.debug
@@ -1,4 +1,4 @@
-FROM golang:1.18
+FROM golang:1.20
 
 RUN apt-get update && apt-get install -y \
     apt-utils telnet netcat-openbsd net-tools jq lsof less


### PR DESCRIPTION
Fixing typo with go tip after I renamed ^1 to tip in https://github.com/go-graphite/go-carbon/pull/539, update Docker base images to go1.20
