### PR TITLE
Optionally disable 404 error logging (fix #563)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: [ 1.17.x, 1.18.x, 1.19.x, 1.20.x, tip ]
+        go: [ 1.18.x, 1.19.x, 1.20.x, 1.21.x, tip ]
 
     steps:
       - name: Set up Go stable

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -64,7 +64,7 @@ jobs:
       - name: Install packaging dependencies
         run: |
           gem install rake fpm:1.10.2 package_cloud
-          GO111MODULE=off go get github.com/mitchellh/gox
+          go install github.com/mitchellh/gox@latest
 
       - name: Check packaging
         run: |

--- a/README.md
+++ b/README.md
@@ -464,6 +464,9 @@ graphite-web-10-strict-mode = true
 # Return a 404 instead of empty results. Set to true if you are serving requests to graphite-web
 empty-result-ok = false
 
+# Do not log 404 (metric not found) errors
+do-not-log-404s = false
+
 # Allows to keep track for "last time readed" between restarts, leave empty to disable
 internal-stats-dir = ""
 # Calculate /render request time percentiles for the bucket, '95' means calculate 95th Percentile.

--- a/carbon/app.go
+++ b/carbon/app.go
@@ -481,6 +481,7 @@ func (app *App) Start(version string) (err error) {
 		carbonserver.SetWhisperData(conf.Whisper.DataDir)
 		carbonserver.SetMaxGlobs(conf.Carbonserver.MaxGlobs)
 		carbonserver.SetEmptyResultOk(conf.Carbonserver.EmptyResultOk)
+		carbonserver.SetDoNotLog404s(conf.Carbonserver.DoNotLog404s)
 		carbonserver.SetFLock(app.Config.Whisper.FLock)
 		carbonserver.SetCompressed(app.Config.Whisper.Compressed)
 		carbonserver.SetRemoveEmptyFile(app.Config.Whisper.RemoveEmptyFile)

--- a/carbon/config.go
+++ b/carbon/config.go
@@ -118,6 +118,7 @@ type carbonserverConfig struct {
 	MaxGlobs                   int        `toml:"max-globs"`
 	FailOnMaxGlobs             bool       `toml:"fail-on-max-globs"`
 	EmptyResultOk              bool       `toml:"empty-result-ok"`
+	DoNotLog404s               bool       `toml:"do-not-log-404s"`
 	MetricsAsCounters          bool       `toml:"metrics-as-counters"`
 	TrigramIndex               bool       `toml:"trigram-index"`
 	InternalStatsDir           string     `toml:"internal-stats-dir"`

--- a/carbonserver/carbonserver.go
+++ b/carbonserver/carbonserver.go
@@ -229,6 +229,7 @@ type CarbonserverListener struct {
 	buckets           int
 	maxGlobs          int
 	emptyResultOk     bool
+	doNotLog404s      bool
 	failOnMaxGlobs    bool
 	percentiles       []int
 	scanFrequency     time.Duration
@@ -507,6 +508,9 @@ func (listener *CarbonserverListener) SetMaxGlobs(maxGlobs int) {
 }
 func (listener *CarbonserverListener) SetEmptyResultOk(emptyResultOk bool) {
 	listener.emptyResultOk = emptyResultOk
+}
+func (listener *CarbonserverListener) SetDoNotLog404s(doNotLog404s bool) {
+	listener.doNotLog404s = doNotLog404s
 }
 func (listener *CarbonserverListener) SetFailOnMaxGlobs(failOnMaxGlobs bool) {
 	listener.failOnMaxGlobs = failOnMaxGlobs

--- a/carbonserver/render.go
+++ b/carbonserver/render.go
@@ -259,12 +259,14 @@ func (listener *CarbonserverListener) renderHandler(wr http.ResponseWriter, req 
 	}
 
 	if response.metricsFetched == 0 && !listener.emptyResultOk {
-		accessLogger.Error("fetch failed",
-			zap.Duration("runtime_seconds", time.Since(t0)),
-			zap.String("reason", "no metrics found"),
-			zap.Int("http_code", http.StatusNotFound),
-			zap.Error(err),
-		)
+		if !listener.doNotLog404s {
+			accessLogger.Error("fetch failed",
+				zap.Duration("runtime_seconds", time.Since(t0)),
+				zap.String("reason", "no metrics found"),
+				zap.Int("http_code", http.StatusNotFound),
+				zap.Error(err),
+			)
+		}
 		http.Error(wr, "Bad request (Not Found)", http.StatusNotFound)
 		return
 	}
@@ -808,11 +810,13 @@ func (listener *CarbonserverListener) Render(req *protov2.MultiFetchRequest, str
 	}
 
 	if metricsFetched == 0 && !listener.emptyResultOk {
-		accessLogger.Error("fetch failed",
-			zap.Duration("runtime_seconds", time.Since(t0)),
-			zap.String("reason", "no metrics found"),
-			zap.Error(err),
-		)
+		if !listener.doNotLog404s {
+			accessLogger.Error("fetch failed",
+				zap.Duration("runtime_seconds", time.Since(t0)),
+				zap.String("reason", "no metrics found"),
+				zap.Error(err),
+			)
+		}
 		return status.New(codes.NotFound, "no metrics found").Err()
 	}
 

--- a/go-carbon.conf.example
+++ b/go-carbon.conf.example
@@ -362,6 +362,9 @@ graphite-web-10-strict-mode = true
 # Return a 404 instead of empty results. Set to true if you are serving requests to graphite-web
 empty-result-ok = false
 
+# Do not log 404 (metric not found) errors
+do-not-log-404s = false
+
 # Allows to keep track for "last time readed" between restarts, leave empty to disable
 internal-stats-dir = ""
 # Calculate /render request time percentiles for the bucket, '95' means calculate 95th Percentile. 


### PR DESCRIPTION
Fix for https://github.com/go-graphite/go-carbon/issues/563
Not sure should we revert logic, and introduce `do-log-404s` with default = true.