### PR TITLE
ci: Use GITHUB_OUTPUT envvar instead of set-output command

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '2.7' # Version range or exact version of a Ruby version to use, using semvers version range syntax.
+          ruby-version: "2.7" # Version range or exact version of a Ruby version to use, using semvers version range syntax.
       - name: Install packaging dependencies
         run: |
           gem install rake fpm:1.10.2 package_cloud
@@ -46,7 +46,7 @@ jobs:
           ARTIFACTS=
           # Upload all deb and rpm packages
           for package in *deb *rpm; do ARTIFACTS=${ARTIFACTS}\"$package\",\ ; done
-          echo ::set-output name=matrix::{\"file\": [${ARTIFACTS} \"sha256sum\", \"md5sum\"]}
+          echo "matrix={\"file\": [${ARTIFACTS} \"sha256sum\", \"md5sum\"]}" >> $GITHUB_OUTPUT
 
       - name: Check version
         id: check_version

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,7 +46,7 @@ jobs:
           ARTIFACTS=
           # Upload all deb and rpm packages
           for package in *deb *rpm; do ARTIFACTS=${ARTIFACTS}\"$package\",\ ; done
-          echo "matrix={\"file\": [${ARTIFACTS} \"sha256sum\", \"md5sum\"]}" >> $GITHUB_OUTPUT
+          echo "matrix={\"file\": [${ARTIFACTS} \"sha256sum\", \"md5sum\"]}" >> "$GITHUB_OUTPUT"
 
       - name: Check version
         id: check_version


### PR DESCRIPTION
`save-state` and `set-output` commands used in GitHub Actions are deprecated and [GitHub recommends using environment files](https://github.blog/changelog/2023-07-24-github-actions-update-on-save-state-and-set-output-commands/).

This PR updates the usage of `set-output` to `$GITHUB_OUTPUT`

Instructions for envvar usage from GitHub docs:

https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter

