### PR TITLE
Speed up fetchData

### DIFF
--- a/README.md
+++ b/README.md
@@ -454,6 +454,9 @@ max-metrics-globbed  = 30000
 # Maximum metrics could be returned in render request (works both all types of
 # indexes) (Default: 1,000,000)
 max-metrics-rendered = 1000
+# Maximum number of goroutines (i.e. threads) to fetch data from disk/cache 
+# (Default: 2 * max-cpu)
+max-fetch-data-goroutines = 0
 
 # graphite-web-10-mode
 # Use Graphite-web 1.0 native structs for pickle response

--- a/carbon/app.go
+++ b/carbon/app.go
@@ -491,6 +491,7 @@ func (app *App) Start() (err error) {
 		carbonserver.SetFailOnMaxGlobs(conf.Carbonserver.FailOnMaxGlobs)
 		carbonserver.SetMaxMetricsGlobbed(conf.Carbonserver.MaxMetricsGlobbed)
 		carbonserver.SetMaxMetricsRendered(conf.Carbonserver.MaxMetricsRendered)
+		carbonserver.SetMaxFetchDataGoroutines(conf.Carbonserver.MaxFetchDataGoroutines)
 		carbonserver.SetBuckets(conf.Carbonserver.Buckets)
 		carbonserver.SetMetricsAsCounters(conf.Carbonserver.MetricsAsCounters)
 		carbonserver.SetScanFrequency(conf.Carbonserver.ScanFrequency.Value())

--- a/carbon/config.go
+++ b/carbon/config.go
@@ -127,8 +127,9 @@ type carbonserverConfig struct {
 	Percentiles                []int      `toml:"stats-percentiles"`
 	CacheScan                  bool       `toml:"cache-scan"`
 
-	MaxMetricsGlobbed  int `toml:"max-metrics-globbed"`
-	MaxMetricsRendered int `toml:"max-metrics-rendered"`
+	MaxMetricsGlobbed      int `toml:"max-metrics-globbed"`
+	MaxMetricsRendered     int `toml:"max-metrics-rendered"`
+	MaxFetchDataGoroutines int `toml:"max-fetch-data-goroutines"`
 
 	TrieIndex       bool `toml:"trie-index"`
 	ConcurrentIndex bool `toml:"concurrent-index"`

--- a/carbonserver/cache_index_test.go
+++ b/carbonserver/cache_index_test.go
@@ -85,6 +85,7 @@ func getTestInfo(t *testing.T) *testInfo {
 	carbonserver.cacheGetRecentMetrics = c.GetRecentNewMetrics
 	carbonserver.metrics = &metricStruct{}
 	carbonserver.exitChan = make(chan struct{})
+	carbonserver.SetMaxFetchDataGoroutines(2)
 
 	return &testInfo{
 		forceChan:     make(chan struct{}),

--- a/carbonserver/carbonserver.go
+++ b/carbonserver/carbonserver.go
@@ -209,11 +209,11 @@ func (q *QueryItem) StoreAndUnlock(data interface{}) {
 	close(q.QueryFinished)
 }
 
-type queryCache struct {
+type expireCache struct {
 	ec *expirecache.Cache
 }
 
-func (q *queryCache) getQueryItem(k string, size uint64, expire int32) *QueryItem {
+func (q *expireCache) getQueryItem(k string, size uint64, expire int32) *QueryItem {
 	emptyQueryItem := &QueryItem{QueryFinished: make(chan struct{})}
 	return q.ec.GetOrSet(k, emptyQueryItem, size, expire).(*QueryItem)
 }
@@ -252,10 +252,10 @@ type CarbonserverListener struct {
 	queryCacheEnabled          bool
 	streamingQueryCacheEnabled bool
 	queryCacheSizeMB           int
-	queryCache                 queryCache
+	queryCache                 expireCache
 	findCacheEnabled           bool
-	findCache                  queryCache
-	expandedGlobsCache         queryCache // TODO: rename queryCache type to be more generic
+	findCache                  expireCache
+	expandedGlobsCache         expireCache
 	trigramIndex               bool
 	trieIndex                  bool
 	concurrentIndex            bool
@@ -479,8 +479,8 @@ func NewCarbonserverListener(cacheGetFunc func(key string) []points.Point) *Carb
 		cacheGet:           cacheGetFunc,
 		logger:             zapwriter.Logger("carbonserver"),
 		accessLogger:       zapwriter.Logger("access"),
-		findCache:          queryCache{ec: expirecache.New(0)},
-		expandedGlobsCache: queryCache{ec: expirecache.New(0)},
+		findCache:          expireCache{ec: expirecache.New(0)},
+		expandedGlobsCache: expireCache{ec: expirecache.New(0)},
 		trigramIndex:       true,
 		percentiles:        []int{100, 99, 98, 95, 75, 50},
 		prometheus: prometheus{

--- a/carbonserver/carbonserver.go
+++ b/carbonserver/carbonserver.go
@@ -1786,7 +1786,7 @@ func (listener *CarbonserverListener) Listen(listen string) error {
 		listener.forceScanChan <- struct{}{}
 	}
 
-	listener.queryCache = queryCache{ec: expirecache.New(uint64(listener.queryCacheSizeMB))}
+	listener.queryCache = expireCache{ec: expirecache.New(uint64(listener.queryCacheSizeMB))}
 
 	// +1 to track every over the number of buckets we track
 	listener.timeBuckets = make([]uint64, listener.buckets+1)
@@ -2224,7 +2224,7 @@ func (listener *CarbonserverListener) grpcServerRatelimitHandler(ctx context.Con
 	return nil
 }
 
-func getWithCache(logger *zap.Logger, cache queryCache, key string, size uint64, expire int32, f func() (interface{}, error)) (result interface{}, fromCache bool, err error) {
+func getWithCache(logger *zap.Logger, cache expireCache, key string, size uint64, expire int32, f func() (interface{}, error)) (result interface{}, fromCache bool, err error) {
 	item := cache.getQueryItem(key, size, expire)
 	res, ok := item.FetchOrLock()
 	switch {

--- a/carbonserver/carbonserver.go
+++ b/carbonserver/carbonserver.go
@@ -524,11 +524,7 @@ func (listener *CarbonserverListener) SetMaxMetricsRendered(max int) {
 	listener.maxMetricsRendered = max
 }
 func (listener *CarbonserverListener) SetMaxFetchDataGoroutines(max int) {
-	if max > 0 {
-		listener.maxFetchDataGoroutines = max
-	} else {
-		listener.maxFetchDataGoroutines = 2 * runtime.GOMAXPROCS(0)
-	}
+	listener.maxFetchDataGoroutines = max
 }
 func (listener *CarbonserverListener) SetFLock(flock bool) {
 	listener.flock = flock

--- a/carbonserver/carbonserver.go
+++ b/carbonserver/carbonserver.go
@@ -246,8 +246,9 @@ type CarbonserverListener struct {
 	compressed        bool
 	removeEmptyFile   bool
 
-	maxMetricsGlobbed  int
-	maxMetricsRendered int
+	maxMetricsGlobbed      int
+	maxMetricsRendered     int
+	maxFetchDataGoroutines int
 
 	queryCacheEnabled          bool
 	streamingQueryCacheEnabled bool
@@ -521,6 +522,13 @@ func (listener *CarbonserverListener) SetMaxMetricsGlobbed(max int) {
 }
 func (listener *CarbonserverListener) SetMaxMetricsRendered(max int) {
 	listener.maxMetricsRendered = max
+}
+func (listener *CarbonserverListener) SetMaxFetchDataGoroutines(max int) {
+	if max > 0 {
+		listener.maxFetchDataGoroutines = max
+	} else {
+		listener.maxFetchDataGoroutines = 2 * runtime.GOMAXPROCS(0)
+	}
 }
 func (listener *CarbonserverListener) SetFLock(flock bool) {
 	listener.flock = flock

--- a/carbonserver/carbonserver_test.go
+++ b/carbonserver/carbonserver_test.go
@@ -373,6 +373,7 @@ func initCarbonserverListener(cache *cache.Cache) (*CarbonserverListener, error)
 	carbonserver.whisperData = path
 	carbonserver.logger = zap.NewNop()
 	carbonserver.metrics = &metricStruct{}
+	carbonserver.SetMaxFetchDataGoroutines(2)
 	return carbonserver, nil
 }
 

--- a/go-carbon.conf.example
+++ b/go-carbon.conf.example
@@ -350,6 +350,9 @@ max-metrics-globbed  = 30000
 # Maximum metrics could be returned in render request (works both all types of
 # indexes) (Default: 1,000,000)
 max-metrics-rendered = 1000
+# Maximum number of goroutines (i.e. threads) to fetch data from disk/cache
+# (Default: 2 x max-cpu)
+max-fetch-data-goroutines = 0
 
 # graphite-web-10-mode
 # Use Graphite-web 1.0 native structs for pickle response


### PR DESCRIPTION
During investigation of slow queries on server with big amount of files I found out that main culprit was on `fetchData` - it's doing data fetch serially, which is slow on hundreds and thousands of files. Main bottleneck should be disk, but we're doing some realtime merging with cache. We can speed up `fetchData` with goroutines, with sane cap (2 x GOMAXPROCS). 
Also contains `queryCache` to `expireCache` struct renaming, as TODO asked.