### PR TITLE
Add govulncheck

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: [ 1.21.x, 1.22.x, 1.23.x, tip ]
+        go: [ 1.22.x, 1.23.x, tip ]
 
     steps:
       - name: Set up Go stable

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,6 +21,7 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: ${{ matrix.go }}
+          check-latest: true
       - name: Set up Go tip
         if: matrix.go == 'tip'
         run: |
@@ -52,6 +53,14 @@ jobs:
         env:
           CGO_ENABLED: 1
 
+      - name: Govulncheck
+        id: govulncheck
+        uses: golang/govulncheck-action@v1
+        with:
+          go-version-input: ${{ matrix.go }}
+          check-latest: true
+          go-package: ./...
+
       - name: Check Docker images
         run: |
           make image
@@ -81,3 +90,12 @@ jobs:
         env:
           PACKAGECLOUD_TOKEN: ${{ secrets.PACKAGECLOUD_TOKEN }}
 
+  govulncheck:
+    runs-on: ubuntu-latest
+    name: Run govulncheck
+    steps:
+      - id: govulncheck
+        uses: golang/govulncheck-action@v1
+        with:
+          go-version-input: 1.20.6
+          go-package: ./...

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -54,6 +54,7 @@ jobs:
           CGO_ENABLED: 1
 
       - name: Govulncheck
+        if: matrix.go != 'tip'
         id: govulncheck
         uses: golang/govulncheck-action@v1
         with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -89,13 +89,3 @@ jobs:
         run: make DEVEL=1 packagecloud-autobuilds
         env:
           PACKAGECLOUD_TOKEN: ${{ secrets.PACKAGECLOUD_TOKEN }}
-
-  govulncheck:
-    runs-on: ubuntu-latest
-    name: Run govulncheck
-    steps:
-      - id: govulncheck
-        uses: golang/govulncheck-action@v1
-        with:
-          go-version-input: 1.20.6
-          go-package: ./...

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,8 @@
 module github.com/go-graphite/go-carbon
 
-go 1.21
-toolchain go1.22.9
+go 1.22
+
+toolchain go1.23.5
 
 require (
 	cloud.google.com/go/pubsub v1.45.3


### PR DESCRIPTION
Removing go 1.21 as unsupported and currently vulnerable