### PR TITLE
Docker: build mulitarchitecture images

### DIFF
--- a/.github/workflows/docker-ghcrio.yml
+++ b/.github/workflows/docker-ghcrio.yml
@@ -1,19 +1,27 @@
-name: Upload Docker images to ghcr.io
+name: Upload Docker images to GitHub Container Registry (ghcr.io)
 
 on:
   push:
-    branches: [ master ]
+    branches: [ master, main ]
     tags: [ 'v*' ]
   pull_request:
-    branches: [ master ]
+    branches: [ master, main ]
 
 jobs:
   docker:
-    name: Build image
+    name: Build images
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
         uses: actions/checkout@v4
+      - name: Set up QEMU
+        if: github.event_name != 'pull_request'
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: arm,arm64
+          cache-image: false
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
       - name: Docker meta
         id: meta
         uses: docker/metadata-action@v5
@@ -28,19 +36,34 @@ jobs:
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}.{{minor}}.{{patch}}
-      - name: Login to ghcr.io
+        env:
+          DOCKER_METADATA_ANNOTATIONS_LEVELS: manifest,index
+      - name: Login to GitHub Container Registry
         if: github.event_name != 'pull_request'
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Build and push
-        id: docker_build
+      - name: Build
+        if: github.event_name == 'pull_request'
         uses: docker/build-push-action@v6
         with:
-          # push for non-pr events
-          push: ${{ github.event_name != 'pull_request' }}
           context: .
+          platforms: linux/amd64
+          push: false
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          annotations: ${{ steps.meta.outputs.annotations }}
+      - name: Build and push
+        if: github.event_name != 'pull_request'
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          annotations: ${{ steps.meta.outputs.annotations }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,23 +1,35 @@
-FROM golang:1.23-alpine AS build
+FROM golang:alpine AS build
+ARG TARGETARCH
 
-COPY . /usr/local/src/go-carbon
-RUN apk add --update git make bash \
- && cd /usr/local/src/go-carbon \
- && make go-carbon \
- && chmod +x go-carbon && cp -fv go-carbon /tmp
+RUN apk add --update git make bash gcc musl-dev
 
-FROM alpine:3
+USER nobody:nogroup
+WORKDIR /usr/local/src/go-carbon
+COPY --chown=nobody:nogroup . .
+RUN --network=none make clean
+RUN --mount=type=cache,id=go-cache,target=/.cache,sharing=locked,uid=65534,gid=65534 make go-carbon
+RUN --mount=type=cache,id=go-cache,target=/.cache,sharing=locked,uid=65534,gid=65534 <<EOT
+if [ "${TARGETARCH:-unknown}" = "amd64" ]; then
+  make run-test COMMAND="test -race" 
+else
+  make run-test COMMAND="test" || true
+fi
+EOT
 
-RUN addgroup -S carbon && adduser -S carbon -G carbon \
-    && mkdir -p /var/lib/graphite/whisper /var/lib/graphite/dump /var/lib/graphite/tagging /var/log/go-carbon /etc/go-carbon/ \
-    && chown -R carbon:carbon /var/lib/graphite/ /var/log/go-carbon
+FROM alpine:latest
 
-COPY --from=build /tmp/go-carbon /usr/sbin/go-carbon
-ADD go-carbon.conf.example /etc/go-carbon/go-carbon.conf
+RUN --network=none addgroup -S carbon && adduser -S carbon -G carbon \
+  && mkdir -p /var/lib/graphite/whisper /etc/go-carbon/ \
+  && chown -R carbon:carbon /var/lib/graphite/
+
+COPY --chown=0:0 --chmod=755 --from=build /usr/local/src/go-carbon/go-carbon /usr/sbin/go-carbon
+ADD go-carbon.docker.conf /etc/go-carbon/go-carbon.conf
 ADD deploy/storage*.conf /etc/go-carbon/
+RUN --network=none /usr/sbin/go-carbon -config-print-default > /etc/go-carbon/go-carbon.default.conf
 
 USER carbon
-CMD ["/usr/sbin/go-carbon", "-daemon=false", "-config", "/etc/go-carbon/go-carbon.conf"]
+ENTRYPOINT ["/usr/sbin/go-carbon"]
+CMD ["-config", "/etc/go-carbon/go-carbon.conf"]
 
-EXPOSE 2003 2004 7002 7003 7007 8080 2003/udp
+EXPOSE 2003/tcp 2003/udp 8080
 VOLUME /var/lib/graphite /etc/go-carbon

--- a/carbon/config.go
+++ b/carbon/config.go
@@ -212,9 +212,14 @@ type Config struct {
 }
 
 func NewLoggingConfig() zapwriter.Config {
-	cfg := zapwriter.NewConfig()
-	cfg.File = "/var/log/go-carbon/go-carbon.log"
-	return cfg
+	return zapwriter.Config{
+		Logger:           "",
+		File:             "stdout",
+		Level:            "info",
+		Encoding:         "console",
+		EncodingTime:     "iso8601",
+		EncodingDuration: "seconds",
+	}
 }
 
 // NewConfig ...

--- a/go-carbon.docker.conf
+++ b/go-carbon.docker.conf
@@ -1,0 +1,45 @@
+[whisper]
+enabled = true
+data-dir = "/var/lib/graphite/whisper"
+schemas-file = "/etc/go-carbon/storage-schemas.conf"
+aggregation-file = "/etc/go-carbon/storage-aggregation.conf"
+sparse-create = true
+
+[cache]
+max-size = 1000000
+write-strategy = "noop"
+bloom-size = 0
+
+[udp]
+listen = ":2003"
+enabled = true
+buffer-size = 0
+
+[tcp]
+listen = ":2003"
+enabled = true
+buffer-size = 0
+
+[carbonserver]
+listen = ":8080"
+enabled = true
+
+[pickle]
+enabled = false
+
+[grpc]
+enabled = false
+
+[carbonlink]
+enabled = false
+
+[dump]
+enabled = false
+
+[[logging]]
+logger = ""
+file = "stdout"
+level = "error"
+encoding = "console"
+encoding-time = ""
+encoding-duration = ""


### PR DESCRIPTION
Thanks to [docker/build-push-action@v6](http://github.com/docker/build-push-action) action now it's easy to build multiarchitecture Docker images. So, I decided to modify `docker-ghcrio.yml` workflow and build (publish) Docker images for **ARM64** (`linux/arm64`) and **ARM** (`linux/arm/v7`,`linux/arm/v6`) architectures. `Dockerfile` was also improved a bit.

Related PR: https://github.com/go-graphite/carbonapi/pull/858