### PR TITLE
Switch systemd unit example to non-forking

### DIFF
--- a/deploy/go-carbon.service
+++ b/deploy/go-carbon.service
@@ -1,12 +1,12 @@
 [Unit]
-Description=Golang implementation of Graphite/Carbon server.
+Description=Golang implementation of Graphite/Carbon server
 Documentation=https://github.com/go-graphite/go-carbon
 After=network-online.target local-fs.target
 Wants=network-online.target local-fs.target
 
 [Service]
-Type=forking
-ExecStart=/usr/bin/go-carbon -config /etc/go-carbon/go-carbon.conf -pidfile /var/run/go-carbon.pid -daemon
+Type=simple
+ExecStart=/usr/bin/go-carbon -config /etc/go-carbon/go-carbon.conf -pidfile /var/run/go-carbon.pid
 ExecReload=/bin/kill -HUP $MAINPID
 KillSignal=USR2
 Restart=on-failure

--- a/deploy/go-carbon.service
+++ b/deploy/go-carbon.service
@@ -6,7 +6,7 @@ Wants=network-online.target local-fs.target
 
 [Service]
 Type=simple
-ExecStart=/usr/bin/go-carbon -config /etc/go-carbon/go-carbon.conf -pidfile /var/run/go-carbon.pid
+ExecStart=/usr/bin/go-carbon -config /etc/go-carbon/go-carbon.conf
 ExecReload=/bin/kill -HUP $MAINPID
 KillSignal=USR2
 Restart=on-failure


### PR DESCRIPTION
This pull request updates the systemd service configuration for `go-carbon` to improve reliability and align with best practices. The main change is switching the service type from `forking` to `simple`, which affects how the service is managed and started.

Service configuration improvements:

* Changed the `Type` from `forking` to `simple` in `deploy/go-carbon.service` to simplify process management and avoid issues with daemonization.
* Removed the `-daemon` flag from the `ExecStart` command, as it is no longer needed with the `simple` service type.
* Minor edit to the `Description` field for consistency