### PR TITLE
Replace MD5 hashing in favor of xxh3

### DIFF
--- a/carbonserver/trie.go
+++ b/carbonserver/trie.go
@@ -1,7 +1,6 @@
 package carbonserver
 
 import (
-	"crypto/md5" // skipcq: GSC-G501
 	"errors"
 	"fmt"
 	"io"
@@ -2296,8 +2295,7 @@ func (*trieIndex) metricName(node *trieNode, name string) string {
 	// WHY: on linux, the maximum filename length is 255, keeping 5 here for
 	// file extension.
 	if len(name) >= 250 {
-		// skipcq: GSC-G401, GO-S1023
-		name = fmt.Sprintf("%s-%x", name[:(250-md5.Size*2-1)], md5.Sum([]byte(name)))
+		name = fmt.Sprintf("%.233s-%.16x", name, helper.HashString(name))
 	}
 	return prefix + name
 }


### PR DESCRIPTION
* updates carbonserver's use of `MD5` with recently added `helper.HashString`
* removes `noqa` tags related to use of `MD5`

A quick follow up to https://github.com/go-graphite/go-carbon/pull/814 this also replaces the use of `MD5` with `xxh3` by way of `helper.HashString`. This should be functionally equivalent but have a better distribution and resistance to hash collisions.