### PR TITLE
switching pipeline to stable/oldstable

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -28,7 +28,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           # We must fetch at least the immediate parents so that if this is
           # a pull request then we can checkout the head.

--- a/.github/workflows/docker-ghcrio.yml
+++ b/.github/workflows/docker-ghcrio.yml
@@ -62,7 +62,7 @@ jobs:
       - prepare
     steps:
       - name: Check out code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           fetch-tags: true
 
@@ -71,10 +71,10 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: ghcr.io/${{ github.repository }}
-      
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
-      
+
       - name: Build
         uses: docker/build-push-action@v6
         with:
@@ -111,14 +111,14 @@ jobs:
 
       - name: Check out code
         if: github.event_name == 'workflow_dispatch'
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           ref: ${{ inputs.ref }}
           fetch-tags: true
 
       - name: Check out code
         if: github.event_name != 'workflow_dispatch'
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           fetch-tags: true
 
@@ -127,17 +127,17 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: ghcr.io/${{ github.repository }}
-      
+
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
         if: ${{ matrix.platform.qemu }}
         with:
           platforms: ${{ matrix.platform.qemu }}
           cache-image: false
-      
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
-        
+
       - name: Login to GitHub Container Registry
         if: needs.prepare.outputs.publish_image
         uses: docker/login-action@v3
@@ -230,5 +230,3 @@ jobs:
 
       - name: Inspect image
         run: docker buildx imagetools inspect ghcr.io/${{ needs.prepare.outputs.github_repository }}:${{ steps.meta.outputs.version }}
-
-

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,11 +17,11 @@ jobs:
       matrix: ${{ steps.build.outputs.matrix }}
     steps:
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: ^1
 
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         name: Checkout
 
       - name: Test

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,9 +2,9 @@ name: Tests
 
 on:
   push:
-    branches: [ master ]
+    branches: [master]
   pull_request:
-    branches: [ master ]
+    branches: [master]
 
 jobs:
   tests:
@@ -12,23 +12,14 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: [ 1.22.x, 1.23.x, 1.24.x, tip ]
+        go: [oldstable, stable]
 
     steps:
       - name: Set up Go stable
-        if: matrix.go != 'tip'
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: ${{ matrix.go }}
-      - name: Set up Go tip
-        if: matrix.go == 'tip'
-        run: |
-          curl -o go.tar.gz -L \
-          https://github.com/AlekSi/golang-tip/releases/download/tip/master.linux-amd64.tar.gz
-          sudo tar -C /usr/local -xzf go.tar.gz
-          sudo ln -s /usr/local/go/bin/* /usr/local/bin/
-          /usr/local/bin/go version
-          echo "PATH=$HOME/go/bin:$HOME/sdk/gotip/bin/:$PATH" >> $GITHUB_ENV
+          check-latest: true
 
       - name: Check out code into the Go module directory
         uses: actions/checkout@v5
@@ -55,7 +46,7 @@ jobs:
           CGO_ENABLED: 1
 
       - name: Govulncheck
-        if: ${{ matrix.go == '1.24.x' }} # only do govulncheck when built with latest stable go
+        if: ${{ matrix.go == 'stable' }} # only do govulncheck when built with latest stable go
         id: govulncheck
         uses: golang/govulncheck-action@v1
         with:
@@ -74,7 +65,7 @@ jobs:
           make sum-files
 
       - name: Upload Artifact
-        if: ${{ matrix.go == '1.24.x' }} # only upload artifact when built with latest stable go
+        if: ${{ matrix.go == 'stable' }} # only upload artifact when built with latest stable go
         id: artifact
         uses: actions/upload-artifact@v6
         with:
@@ -87,7 +78,7 @@ jobs:
             md5sum
 
       - name: Push packages to the autobuilds repo
-        if: ${{ github.event_name == 'push' && matrix.go == '1.24.x' }} # only when built from master with latest stable go
+        if: ${{ github.event_name == 'push' && matrix.go == 'stable' }} # only when built from master with latest stable go
         run: make DEVEL=1 packagecloud-autobuilds
         env:
           PACKAGECLOUD_TOKEN: ${{ secrets.PACKAGECLOUD_TOKEN }}


### PR DESCRIPTION
We don't need to update go versions manually, and supporting stable and old stable is a common policy in go world.
Also updating some actions.