### PR TITLE
Add User/Group specification to systemd unit example

### DIFF
--- a/deploy/go-carbon.service
+++ b/deploy/go-carbon.service
@@ -6,6 +6,8 @@ Wants=network-online.target local-fs.target
 
 [Service]
 Type=simple
+User=carbon
+Group=carbon
 ExecStart=/usr/bin/go-carbon -config /etc/go-carbon/go-carbon.conf
 ExecReload=/bin/kill -HUP $MAINPID
 KillSignal=USR2


### PR DESCRIPTION
This is a follow up to https://github.com/go-graphite/go-carbon/pull/808 to make sure that we have a non-root user specified in the service unit as the current code has no code path to change the user/group of the service outside of the forking/demonization code.