### PR TITLE
Update Cache.Add to use helper.HashString

### DIFF
--- a/cache/cache.go
+++ b/cache/cache.go
@@ -11,8 +11,6 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/cespare/xxhash/v2"
-
 	"github.com/go-graphite/go-carbon/helper"
 	"github.com/go-graphite/go-carbon/points"
 	"github.com/go-graphite/go-carbon/tags"
@@ -334,9 +332,9 @@ func (c *Cache) Add(p *points.Points) {
 	if c.newMetricsChan != nil && c.newMetricCf != nil {
 		// add metric to new metric channel if missed in bloom
 		// despite what we have it in cache (new behaviour)
-		if !c.newMetricCf.Has(xxhash.Sum64([]byte(p.Metric))) {
+		if !c.newMetricCf.Has(helper.HashString(p.Metric)) {
 			sendMetricToNewMetricChan(c, p.Metric)
-			c.newMetricCf.Add(xxhash.Sum64([]byte(p.Metric)))
+			c.newMetricCf.Add(helper.HashString(p.Metric))
 		}
 
 	}

--- a/cache/cache_test.go
+++ b/cache/cache_test.go
@@ -96,5 +96,5 @@ func benchmarkStrategy(b *testing.B, strategy string) {
 }
 
 func BenchmarkUpdateQueueMax(b *testing.B)  { benchmarkStrategy(b, "max") }
-func BenchmarkUpdateQueueSort(b *testing.B) { benchmarkStrategy(b, "sort") }
+func BenchmarkUpdateQueueSort(b *testing.B) { benchmarkStrategy(b, "sorted") }
 func BenchmarkUpdateQueueNoop(b *testing.B) { benchmarkStrategy(b, "noop") }

--- a/go.mod
+++ b/go.mod
@@ -36,7 +36,6 @@ require (
 )
 
 require (
-	github.com/cespare/xxhash/v2 v2.3.0
 	github.com/greatroar/blobloom v0.8.1
 	github.com/zeebo/xxh3 v1.0.2
 	golang.org/x/net v0.43.0
@@ -51,6 +50,7 @@ require (
 	cloud.google.com/go/iam v1.5.2 // indirect
 	cloud.google.com/go/pubsub/v2 v2.0.0 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
+	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/eapache/go-resiliency v1.7.0 // indirect
 	github.com/eapache/go-xerial-snappy v0.0.0-20230731223053-c322873962e3 // indirect


### PR DESCRIPTION
* removes direct import of xxhash/v2
* replaces calls to `xxhash.Sum64` with `helper.HashString`
* fixes typo in `cache_test.go` benchmark
* updates go.mod to match removal of direct import

I missed this previously when working on #816 and #814, functionally this replaces xxhash/v2 with xxh3 in 2 call points which should have essentially no performance impact, but has the upside of further standardizing on a single fast 64 bit non-cryptographic hash for general purposes.

The test fix included is unrelated, but I noticed it when validating that my changes didn't break any tests